### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The Model Context Protocol (MCP) enables AI models to interact with external too
 
 Requires the Local REST API plugin in Obsidian.
 
+<a href="https://glama.ai/mcp/servers/syuh40cxyk"><img width="380" height="200" src="https://glama.ai/mcp/servers/syuh40cxyk/badge" alt="Obsidian Server MCP server" /></a>
+
 ## Features
 
 ### File Operations


### PR DESCRIPTION
This PR adds a badge for the [Obsidian MCP Server](https://glama.ai/mcp/servers/syuh40cxyk) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/syuh40cxyk"><img width="380" height="200" src="https://glama.ai/mcp/servers/syuh40cxyk/badge" alt="Obsidian Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.