### PR TITLE
Add "bin" section to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-mcp-server",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-mcp-server",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.2",
@@ -26,6 +26,9 @@
         "winston": "^3.17.0",
         "yaml": "^2.7.1",
         "zod": "^3.24.3"
+      },
+      "bin": {
+        "obsidian-mcp-server": "build/index.js"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "rebuild": "npm run clean && npm run build",
     "tree": "npx ts-node --esm scripts/tree.ts"
   },
+  "bin": {
+    "obsidian-mcp-server": "build/index.js"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.10.2",
     "@types/node": "^22.14.1",


### PR DESCRIPTION
This allows the server to be run without cloning the repo, using `deno npm:obsidian-mcp-server` or `npx obsidian-mcp-server`.
