### PR TITLE
feat: Add support for custom HTTP headers via OBSIDIAN_CUSTOM_HEADERS env var

### DIFF
--- a/.github/workflows/argus-review.yaml
+++ b/.github/workflows/argus-review.yaml
@@ -1,0 +1,22 @@
+name: Argus Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: Simplifying-Cloud/pr-review-action@v1
+        with:
+          llm_base_url: 'https://openrouter.ai/api/v1/'
+          llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          llm_model: ${{ vars.LLM_MODEL || 'anthropic/claude-sonnet-4-6' }}
+          review_focus: |
+            - Security: injection, auth bypass, secrets in code
+            - Error handling: ensure errors are propagated, not swallowed
+            - Simplicity: flag over-engineering and unnecessary complexity
+            - Dependencies: flag unnecessary 3rd party additions

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -104,6 +104,18 @@ const EnvSchema = z.object({
     .int()
     .positive()
     .default(30000),
+  OBSIDIAN_CUSTOM_HEADERS: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (!val) return {};
+      try {
+        return JSON.parse(val);
+      } catch {
+        console.error("Warning: OBSIDIAN_CUSTOM_HEADERS is not valid JSON, ignoring.");
+        return {};
+      }
+    }),
 });
 
 const parsedEnv = EnvSchema.safeParse(process.env);
@@ -214,6 +226,7 @@ export const config = {
   obsidianCacheRefreshIntervalMin: env.OBSIDIAN_CACHE_REFRESH_INTERVAL_MIN,
   obsidianEnableCache: env.OBSIDIAN_ENABLE_CACHE,
   obsidianApiSearchTimeoutMs: env.OBSIDIAN_API_SEARCH_TIMEOUT_MS,
+  obsidianCustomHeaders: env.OBSIDIAN_CUSTOM_HEADERS as Record<string, string>,
 };
 
 /**

--- a/src/services/obsidianRestAPI/service.ts
+++ b/src/services/obsidianRestAPI/service.ts
@@ -57,6 +57,7 @@ export class ObsidianRestApiService {
       headers: {
         Authorization: `Bearer ${this.apiKey}`,
         Accept: "application/json", // Default accept type
+        ...config.obsidianCustomHeaders, // Custom headers (e.g., CF Access service token)
       },
       timeout: 60000, // Increased timeout to 60 seconds (was 15000)
       httpsAgent,


### PR DESCRIPTION
## Summary

This PR adds support for injecting custom HTTP headers into all Obsidian REST API requests via a new `OBSIDIAN_CUSTOM_HEADERS` environment variable.

**Use case:** When the Obsidian API is behind an authenticating reverse proxy (e.g., Cloudflare Access, OAuth2 Proxy, Authelia), users currently need to run a separate local proxy to inject authentication headers. This change eliminates that requirement.

## Changes

- Added `OBSIDIAN_CUSTOM_HEADERS` to the config schema with JSON parsing and error handling
- Spread custom headers into the axios instance creation

## Usage

```bash
OBSIDIAN_CUSTOM_HEADERS='{"CF-Access-Client-Id":"...","CF-Access-Client-Secret":"..."}'
```

Or in Claude Code's MCP config:

```json
{
  "env": {
    "OBSIDIAN_API_KEY": "...",
    "OBSIDIAN_BASE_URL": "https://obsidian-api.example.com",
    "OBSIDIAN_CUSTOM_HEADERS": "{\"CF-Access-Client-Id\":\"...\",\"CF-Access-Client-Secret\":\"...\"}"
  }
}
```

## Implementation Details

- If the env var is not set, defaults to empty object (no headers added)
- If the env var contains invalid JSON, logs a warning and defaults to empty object
- Headers are spread into the axios instance, so they're included in every request
- Minimal change: 14 lines across 2 files

## Testing

Tested with Cloudflare Access protecting the Obsidian REST API endpoint. Without the custom headers, requests return 403. With headers, requests succeed.

🤖 Generated with [Claude Code](https://claude.ai/code)