### PR TITLE
fix(docker): Set NODE_ENV=development in builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN npm ci --only=production
 # Build the application
 FROM base AS builder
 WORKDIR /usr/src/app
+# Override NODE_ENV to ensure dev dependencies (like @types/*) are installed
+ENV NODE_ENV=development
 # Copy dependency manifests and install *all* dependencies (including dev)
 COPY package.json package-lock.json* ./
 RUN npm ci


### PR DESCRIPTION
## Summary

The Dockerfile build fails with TypeScript errors because dev dependencies aren't installed in the builder stage.

**Error:**
```
src/mcp-server/tools/obsidianManageFrontmatterTool/logic.ts(2,22): error TS7016: Could not find a declaration file for module 'js-yaml'.
```

**Root cause:** The base stage sets `NODE_ENV=production`, which causes `npm ci` in the builder stage to skip devDependencies (like `@types/js-yaml`) even without the `--only=production` flag.

**Fix:** Explicitly set `NODE_ENV=development` in the builder stage to ensure all dependencies are available for TypeScript compilation.

## Test plan

- [x] Build Docker image: `docker build -t obsidian-mcp-server .`
- [x] Verify container starts: `docker run -e OBSIDIAN_API_KEY=test obsidian-mcp-server`

---

🤖 Generated with [Claude Code](https://claude.ai/code)