### PR TITLE
Add RFC 7662 Token Introspection auth strategy

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -25,11 +25,14 @@ The server can run using different communication transports, configured via envi
 - **`MCP_HTTP_HOST`**: Host address for the HTTP server (Default: `127.0.0.1`). Used only if `MCP_TRANSPORT_TYPE=http`.
 - **`MCP_ALLOWED_ORIGINS`**: Comma-separated list of allowed origins for HTTP requests (e.g., `http://localhost:8080,https://my-frontend.com`). Used only if `MCP_TRANSPORT_TYPE=http`.
 - **`MCP_LOG_LEVEL`**: Minimum logging level for the server (e.g., "debug", "info", "warning", "error", "notice", "crit", "alert", "emerg"). Defaults to "info". Affects both file logging and MCP notifications.
-- **`MCP_AUTH_MODE`**: Authentication strategy to use for the HTTP transport. Can be `jwt` or `oauth`.
+- **`MCP_AUTH_MODE`**: Authentication strategy to use for the HTTP transport. Can be `jwt`, `oauth`, or `introspection`.
 - **`MCP_AUTH_SECRET_KEY`**: **Required if `MCP_AUTH_MODE=jwt`**. Secret key (min 32 chars) for signing/verifying JWTs. **MUST be set in production for JWT mode.**
 - **`OAUTH_ISSUER_URL`**: **Required if `MCP_AUTH_MODE=oauth`**. The URL of the OAuth 2.1 token issuer.
 - **`OAUTH_AUDIENCE`**: **Required if `MCP_AUTH_MODE=oauth`**. The audience claim for the OAuth tokens.
 - **`OAUTH_JWKS_URI`**: Optional URI for the JSON Web Key Set. If omitted, it will be derived from the `OAUTH_ISSUER_URL`.
+- **`TOKEN_INTROSPECTION_URL`**: **Required if `MCP_AUTH_MODE=introspection`**. The URL of the RFC 7662 token introspection endpoint.
+- **`TOKEN_INTROSPECTION_CLIENT_ID`**: Optional. Client ID for authenticating to the introspection endpoint (HTTP Basic Auth).
+- **`TOKEN_INTROSPECTION_CLIENT_SECRET`**: Optional. Client secret for authenticating to the introspection endpoint (HTTP Basic Auth).
 - **`OBSIDIAN_API_KEY`**: **Required.** API key for the Obsidian Local REST API plugin.
 - **`OBSIDIAN_BASE_URL`**: **Required.** Base URL for the Obsidian Local REST API (e.g., `http://127.0.0.1:27123`).
 - **`OBSIDIAN_VERIFY_SSL`**: Set to `false` to disable SSL certificate verification for the Obsidian API (e.g., for self-signed certs). Defaults to `true`.
@@ -160,7 +163,7 @@ Servers expose functionality via:
 - **Input Validation:** Use schemas (Zod), sanitize inputs (paths, HTML, SQL).
 - **Access Control:** Least privilege, respect roots.
 - **Transport Security:**
-  - **HTTP:** Pluggable authentication (`jwt` or `oauth`) via middleware in `src/mcp-server/transports/auth/`. **Requires appropriate environment variables to be set for the chosen mode.** Validate `Origin` header (via CORS middleware). Use HTTPS in production. Bind to `127.0.0.1` for local servers.
+  - **HTTP:** Pluggable authentication (`jwt`, `oauth`, or `introspection`) via middleware in `src/mcp-server/transports/auth/`. **Requires appropriate environment variables to be set for the chosen mode.** Validate `Origin` header (via CORS middleware). Use HTTPS in production. Bind to `127.0.0.1` for local servers.
   - **Stdio:** Authentication typically handled by the host process. Best practice is to not apply authentication to MCP Server stdio processes.
 - **Secrets Management:** Use env vars (`MCP_AUTH_SECRET_KEY`, `OBSIDIAN_API_KEY`) or secrets managers, avoid hardcoding/logging.
 - **Dependency Security:** Keep dependencies updated (`npm audit`).
@@ -1187,7 +1190,7 @@ This project includes several utility scripts located in the `scripts/` director
 
 - **Main Entry**: `src/index.ts` (Initializes server, handles startup/shutdown)
 - **Server Setup**: `src/mcp-server/server.ts` (Handles transport logic, session management, instantiates services, registers tools/resources)
-- **HTTP Auth Middleware**: `src/mcp-server/transports/auth/` (contains strategies for JWT and OAuth)
+- **HTTP Auth Middleware**: `src/mcp-server/transports/auth/` (contains strategies for JWT, OAuth, and Token Introspection)
 - **Configuration**: `src/config/index.ts` (Loads env vars, package info, initializes logger, Obsidian API config)
 - **Obsidian Service**: `src/services/obsidianRestAPI/` (Service, methods, types for Obsidian API)
 - **Vault Cache Service**: `src/services/obsidianRestAPI/vaultCache/` (Service for caching vault structure)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Token Introspection Auth**: Added RFC 7662 Token Introspection as a third authentication strategy (`MCP_AUTH_MODE=introspection`). This enables validation of opaque bearer tokens against a remote introspection endpoint, complementing the existing JWT and OAuth 2.1 strategies. Configure with `TOKEN_INTROSPECTION_URL`, and optionally `TOKEN_INTROSPECTION_CLIENT_ID` and `TOKEN_INTROSPECTION_CLIENT_SECRET` for client authentication.
+
 ## [2.0.7] - 2025-06-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -140,11 +140,14 @@ Configure the server using environment variables. These environmental variables 
 | `MCP_HTTP_PORT`                       | Port for the HTTP server.                                                | No                   | `3010`                   |
 | `MCP_HTTP_HOST`                       | Host for the HTTP server.                                                | No                   | `127.0.0.1`              |
 | `MCP_ALLOWED_ORIGINS`                 | Comma-separated origins for CORS. **Set for production.**                | No                   | (none)                   |
-| `MCP_AUTH_MODE`                       | Authentication strategy: `jwt` or `oauth`.                               | No                   | (none)                   |
+| `MCP_AUTH_MODE`                       | Authentication strategy: `jwt`, `oauth`, or `introspection`.             | No                   | (none)                   |
 | **`MCP_AUTH_SECRET_KEY`**             | 32+ char secret for JWT. **Required for `jwt` mode.**                    | **Yes (if `jwt`)**   | `undefined`              |
 | `OAUTH_ISSUER_URL`                    | URL of the OAuth 2.1 issuer.                                             | **Yes (if `oauth`)** | `undefined`              |
 | `OAUTH_AUDIENCE`                      | Audience claim for OAuth tokens.                                         | **Yes (if `oauth`)** | `undefined`              |
 | `OAUTH_JWKS_URI`                      | URI for the JSON Web Key Set (optional, derived from issuer if omitted). | No                   | (derived)                |
+| `TOKEN_INTROSPECTION_URL`             | URL of the RFC 7662 token introspection endpoint.                        | **Yes (if `introspection`)** | `undefined`        |
+| `TOKEN_INTROSPECTION_CLIENT_ID`       | Client ID for authenticating to the introspection endpoint.              | No                   | `undefined`              |
+| `TOKEN_INTROSPECTION_CLIENT_SECRET`   | Client secret for authenticating to the introspection endpoint.          | No                   | `undefined`              |
 | `MCP_LOG_LEVEL`                       | Logging level (`debug`, `info`, `error`, etc.).                          | No                   | `info`                   |
 | `OBSIDIAN_VERIFY_SSL`                 | Set to `false` to disable SSL verification.                              | No                   | `true`                   |
 | `OBSIDIAN_ENABLE_CACHE`               | Set to `true` to enable the in-memory vault cache.                       | No                   | `true`                   |

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -72,7 +72,7 @@ const EnvSchema = z.object({
   MCP_HTTP_PORT: z.coerce.number().int().positive().default(3010),
   MCP_HTTP_HOST: z.string().default("127.0.0.1"),
   MCP_ALLOWED_ORIGINS: z.string().optional(),
-  MCP_AUTH_MODE: z.enum(["jwt", "oauth"]).optional(),
+  MCP_AUTH_MODE: z.enum(["jwt", "oauth", "introspection"]).optional(),
   MCP_AUTH_SECRET_KEY: z
     .string()
     .min(
@@ -83,6 +83,10 @@ const EnvSchema = z.object({
   OAUTH_ISSUER_URL: z.string().url().optional(),
   OAUTH_AUDIENCE: z.string().optional(),
   OAUTH_JWKS_URI: z.string().url().optional(),
+  // --- Token Introspection (RFC 7662) ---
+  TOKEN_INTROSPECTION_URL: z.string().url().optional(),
+  TOKEN_INTROSPECTION_CLIENT_ID: z.string().optional(),
+  TOKEN_INTROSPECTION_CLIENT_SECRET: z.string().optional(),
   // --- Obsidian Specific Config ---
   OBSIDIAN_API_KEY: z.string().min(1, "OBSIDIAN_API_KEY cannot be empty"),
   OBSIDIAN_BASE_URL: z.string().url().default("http://127.0.0.1:27123"),
@@ -208,6 +212,10 @@ export const config = {
   oauthIssuerUrl: env.OAUTH_ISSUER_URL,
   oauthAudience: env.OAUTH_AUDIENCE,
   oauthJwksUri: env.OAUTH_JWKS_URI,
+  // Token Introspection (RFC 7662)
+  tokenIntrospectionUrl: env.TOKEN_INTROSPECTION_URL,
+  tokenIntrospectionClientId: env.TOKEN_INTROSPECTION_CLIENT_ID,
+  tokenIntrospectionClientSecret: env.TOKEN_INTROSPECTION_CLIENT_SECRET,
   obsidianApiKey: env.OBSIDIAN_API_KEY,
   obsidianBaseUrl: env.OBSIDIAN_BASE_URL,
   obsidianVerifySsl: env.OBSIDIAN_VERIFY_SSL,

--- a/src/mcp-server/transports/auth/index.ts
+++ b/src/mcp-server/transports/auth/index.ts
@@ -10,3 +10,4 @@ export type { AuthInfo } from "./core/authTypes.js";
 
 export { mcpAuthMiddleware as jwtAuthMiddleware } from "./strategies/jwt/jwtMiddleware.js";
 export { oauthMiddleware } from "./strategies/oauth/oauthMiddleware.js";
+export { tokenIntrospectionMiddleware } from "./strategies/introspection/tokenIntrospectionMiddleware.js";

--- a/src/mcp-server/transports/auth/strategies/introspection/tokenIntrospectionMiddleware.ts
+++ b/src/mcp-server/transports/auth/strategies/introspection/tokenIntrospectionMiddleware.ts
@@ -1,0 +1,230 @@
+/**
+ * @fileoverview Hono middleware for OAuth 2.0 Token Introspection (RFC 7662).
+ * This middleware validates opaque bearer tokens by calling a remote introspection endpoint.
+ * Unlike JWT validation which is done locally, opaque tokens must be validated by the
+ * authorization server that issued them.
+ *
+ * RFC 7662: https://datatracker.ietf.org/doc/html/rfc7662
+ *
+ * @module src/mcp-server/transports/auth/strategies/introspection/tokenIntrospectionMiddleware
+ */
+
+import { HttpBindings } from "@hono/node-server";
+import { Context, Next } from "hono";
+import { config } from "../../../../../config/index.js";
+import { BaseErrorCode, McpError } from "../../../../../types-global/errors.js";
+import { logger, requestContextService } from "../../../../../utils/index.js";
+import { authContext } from "../../core/authContext.js";
+import type { AuthInfo } from "../../core/authTypes.js";
+
+// --- Startup Validation ---
+if (config.mcpAuthMode === "introspection") {
+  if (!config.tokenIntrospectionUrl) {
+    throw new Error(
+      "TOKEN_INTROSPECTION_URL must be set when MCP_AUTH_MODE is 'introspection'",
+    );
+  }
+  logger.info(
+    "Token Introspection mode enabled. Validating tokens against introspection endpoint.",
+    requestContextService.createRequestContext({
+      introspectionUrl: config.tokenIntrospectionUrl,
+    }),
+  );
+}
+
+/**
+ * Response from the token introspection endpoint (RFC 7662 Section 2.2)
+ */
+interface IntrospectionResponse {
+  /** REQUIRED. Boolean indicator of whether the token is active */
+  active: boolean;
+  /** OPTIONAL. A space-separated list of scopes */
+  scope?: string;
+  /** OPTIONAL. Client identifier for the OAuth 2.0 client */
+  client_id?: string;
+  /** OPTIONAL. Human-readable identifier for the resource owner */
+  username?: string;
+  /** OPTIONAL. Type of the token (e.g., "Bearer") */
+  token_type?: string;
+  /** OPTIONAL. Unix timestamp indicating when the token will expire */
+  exp?: number;
+  /** OPTIONAL. Unix timestamp indicating when the token was issued */
+  iat?: number;
+  /** OPTIONAL. Unix timestamp indicating when the token is not to be used before */
+  nbf?: number;
+  /** OPTIONAL. Subject of the token (usually user ID) */
+  sub?: string;
+  /** OPTIONAL. String representing the intended audience */
+  aud?: string | string[];
+  /** OPTIONAL. String representing the issuer */
+  iss?: string;
+  /** OPTIONAL. String identifier for the token */
+  jti?: string;
+}
+
+// Simple in-memory cache for introspection results
+// This avoids calling the introspection endpoint on every request
+const tokenCache = new Map<
+  string,
+  { response: IntrospectionResponse; expiresAt: number }
+>();
+const CACHE_TTL_MS = 60000; // Cache for 60 seconds
+
+/**
+ * Calls the token introspection endpoint to validate an opaque token.
+ * @param token - The bearer token to validate
+ * @returns The introspection response
+ */
+async function introspectToken(token: string): Promise<IntrospectionResponse> {
+  // Check cache first
+  const cached = tokenCache.get(token);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.response;
+  }
+
+  const introspectionUrl = config.tokenIntrospectionUrl!;
+
+  // Build the request body (RFC 7662 Section 2.1)
+  const body = new URLSearchParams();
+  body.append("token", token);
+
+  // Build headers
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    Accept: "application/json",
+  };
+
+  // Add client authentication if configured
+  // RFC 7662 Section 2.1: The introspection endpoint MAY require client authentication
+  if (config.tokenIntrospectionClientId && config.tokenIntrospectionClientSecret) {
+    // Use HTTP Basic Auth for client credentials
+    const credentials = Buffer.from(
+      `${config.tokenIntrospectionClientId}:${config.tokenIntrospectionClientSecret}`,
+    ).toString("base64");
+    headers["Authorization"] = `Basic ${credentials}`;
+  }
+
+  const response = await fetch(introspectionUrl, {
+    method: "POST",
+    headers,
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "Unknown error");
+    throw new Error(
+      `Token introspection failed: HTTP ${response.status} - ${errorText}`,
+    );
+  }
+
+  const result = (await response.json()) as IntrospectionResponse;
+
+  // Cache the result
+  tokenCache.set(token, {
+    response: result,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+
+  // Clean up old cache entries periodically
+  if (tokenCache.size > 1000) {
+    const now = Date.now();
+    for (const [key, value] of tokenCache.entries()) {
+      if (value.expiresAt < now) {
+        tokenCache.delete(key);
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Hono middleware for validating opaque bearer tokens via RFC 7662 Token Introspection.
+ * @param c - The Hono context object.
+ * @param next - The function to call to proceed to the next middleware.
+ */
+export async function tokenIntrospectionMiddleware(
+  c: Context<{ Bindings: HttpBindings }>,
+  next: Next,
+) {
+  // If introspection is not the configured auth mode, skip this middleware.
+  if (config.mcpAuthMode !== "introspection") {
+    return await next();
+  }
+
+  const context = requestContextService.createRequestContext({
+    operation: "tokenIntrospectionMiddleware",
+    httpMethod: c.req.method,
+    httpPath: c.req.path,
+  });
+
+  const authHeader = c.req.header("Authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    throw new McpError(
+      BaseErrorCode.UNAUTHORIZED,
+      "Missing or invalid token format.",
+    );
+  }
+
+  const token = authHeader.substring(7);
+
+  try {
+    const introspectionResult = await introspectToken(token);
+
+    // Check if token is active (RFC 7662 Section 2.2)
+    if (!introspectionResult.active) {
+      logger.warning("Token introspection returned inactive token.", context);
+      throw new McpError(
+        BaseErrorCode.UNAUTHORIZED,
+        "Token is inactive or expired.",
+      );
+    }
+
+    // Extract scopes
+    const scopes = introspectionResult.scope
+      ? introspectionResult.scope.split(" ").filter(Boolean)
+      : [];
+
+    // Extract client ID
+    const clientId = introspectionResult.client_id;
+    if (!clientId) {
+      logger.warning(
+        "Token introspection did not return a client_id.",
+        context,
+      );
+      // Some providers may not return client_id, so we use a placeholder
+    }
+
+    const authInfo: AuthInfo = {
+      token,
+      clientId: clientId || "unknown",
+      scopes,
+      subject: introspectionResult.sub,
+    };
+
+    logger.debug("Token introspection successful.", {
+      ...context,
+      clientId,
+      scopes,
+      subject: introspectionResult.sub,
+    });
+
+    // Attach to the raw request and store in AsyncLocalStorage
+    c.env.incoming.auth = authInfo;
+    await authContext.run({ authInfo }, next);
+  } catch (error: unknown) {
+    if (error instanceof McpError) {
+      throw error;
+    }
+
+    logger.error(
+      `Token introspection error: ${error instanceof Error ? error.message : String(error)}`,
+      context,
+    );
+
+    throw new McpError(
+      BaseErrorCode.UNAUTHORIZED,
+      `Token validation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+}

--- a/src/mcp-server/transports/httpTransport.ts
+++ b/src/mcp-server/transports/httpTransport.ts
@@ -35,6 +35,7 @@ import {
 import {
   jwtAuthMiddleware,
   oauthMiddleware,
+  tokenIntrospectionMiddleware,
   type AuthInfo,
 } from "./auth/index.js";
 import { httpErrorHandler } from "./httpErrorHandler.js";
@@ -176,11 +177,15 @@ export async function startHttpTransport(
     await next();
   });
 
+  // Apply authentication middleware based on configured mode
   if (config.mcpAuthMode === "oauth") {
     app.use(MCP_ENDPOINT_PATH, oauthMiddleware);
-  } else {
+  } else if (config.mcpAuthMode === "introspection") {
+    app.use(MCP_ENDPOINT_PATH, tokenIntrospectionMiddleware);
+  } else if (config.mcpAuthMode === "jwt") {
     app.use(MCP_ENDPOINT_PATH, jwtAuthMiddleware);
   }
+  // If no auth mode is set, no authentication middleware is applied
 
   // Centralized Error Handling
   app.onError(httpErrorHandler);

--- a/src/mcp-server/transports/httpTransport.ts
+++ b/src/mcp-server/transports/httpTransport.ts
@@ -177,15 +177,16 @@ export async function startHttpTransport(
     await next();
   });
 
-  // Apply authentication middleware based on configured mode
+  // Apply authentication middleware based on configured mode.
+  // JWT is the default fallthrough to preserve the existing dev-mode bypass behavior
+  // when MCP_AUTH_MODE is not explicitly set.
   if (config.mcpAuthMode === "oauth") {
     app.use(MCP_ENDPOINT_PATH, oauthMiddleware);
   } else if (config.mcpAuthMode === "introspection") {
     app.use(MCP_ENDPOINT_PATH, tokenIntrospectionMiddleware);
-  } else if (config.mcpAuthMode === "jwt") {
+  } else {
     app.use(MCP_ENDPOINT_PATH, jwtAuthMiddleware);
   }
-  // If no auth mode is set, no authentication middleware is applied
 
   // Centralized Error Handling
   app.onError(httpErrorHandler);


### PR DESCRIPTION
Fixes #31

Adds `MCP_AUTH_MODE=introspection` for validating opaque bearer tokens via a remote introspection endpoint (RFC 7662).

- New middleware at `src/mcp-server/transports/auth/strategies/introspection/`
- Follows existing jwt/oauth middleware patterns (ErrorHandler, client_id required, authContext)
- Three new env vars: `TOKEN_INTROSPECTION_URL`, `TOKEN_INTROSPECTION_CLIENT_ID`, `TOKEN_INTROSPECTION_CLIENT_SECRET`
- JWT remains the default fallthrough when `MCP_AUTH_MODE` is unset
- In-memory cache (60s TTL) to avoid calling the introspection endpoint on every request
- Updated README, CHANGELOG, and .clinerules