### PR TITLE
feat: add obsidian_omnisearch tool via Omnisearch HTTP API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+node_modules
+dist
+logs
+*.log
+.env
+.env.*
+docs
+*.md
+repomix-output.*
+.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # ---- Base Node ----
 # Use a specific Node.js version known to work, Alpine for smaller size
-FROM node:23-alpine AS base
+FROM node:23-slim AS base
 WORKDIR /usr/src/app
 ENV NODE_ENV=production
 
@@ -14,15 +14,14 @@ COPY package.json package-lock.json* ./
 RUN npm ci --only=production
 
 # ---- Builder ----
-# Build the application
+# Build the application. NODE_ENV is inherited as "production" from the base
+# stage, which makes `npm ci` skip devDependencies; override with --include=dev
+# so TypeScript can resolve @types/* at compile time.
 FROM base AS builder
 WORKDIR /usr/src/app
-# Copy dependency manifests and install *all* dependencies (including dev)
 COPY package.json package-lock.json* ./
-RUN npm ci
-# Copy the rest of the source code
+RUN npm ci --include=dev
 COPY . .
-# Build the TypeScript project
 RUN npm run build
 
 # ---- Runner ----
@@ -36,12 +35,19 @@ COPY --from=builder /usr/src/app/dist ./dist
 # Copy package.json (needed for potential runtime info, like version)
 COPY package.json .
 
-# Create a non-root user and switch to it
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
-USER appuser
+# The node:23-slim image ships a `node` user with uid/gid 1000,
+# matching the host user that owns the bind-mounted vault.
+# Create the logs directory inside the project tree (config rejects LOGS_DIR
+# outside of it as a safety check) and the HF cache root we expose as a volume.
+RUN mkdir -p /data/hf /usr/src/app/logs && \
+    chown -R node:node /data /usr/src/app/logs
+USER node
 
-# Expose port if the application runs a server (adjust if needed)
-# EXPOSE 3000
+# HuggingFace model cache goes on a mounted volume so we don't re-download
+# on every container recreate.
+ENV HF_HOME=/data/hf
 
-# Command to run the application
+# Default HTTP port for the streamable-HTTP MCP transport.
+EXPOSE 3010
+
 CMD ["node", "dist/index.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.14.4",
+        "@huggingface/transformers": "^4.0.1",
         "@modelcontextprotocol/inspector": "^0.14.3",
         "@modelcontextprotocol/sdk": "^1.13.0",
         "@types/sanitize-html": "^2.16.0",
@@ -78,6 +79,15 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.1.tgz",
@@ -140,6 +150,471 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.6.tgz",
+      "integrity": "sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.0.1.tgz",
+      "integrity": "sha512-tAQYEy+cnW0ku/NxBSjFXCymi+DZa1/JkoGf4McxjzO36CZZIL/J4TF6X7i/tzs75yTjshUDgsvSz03s2xym2A==",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "@huggingface/tokenizers": "^0.1.3",
+        "onnxruntime-node": "1.24.3",
+        "onnxruntime-web": "1.25.0-dev.20260327-722743c0e2",
+        "sharp": "^0.34.5"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -289,6 +764,60 @@
       "engines": {
         "node": ">=16.20.0"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -1238,6 +1767,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1341,6 +1878,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -1838,6 +2381,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -1848,6 +2407,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -1867,6 +2442,19 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -2042,6 +2630,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2191,6 +2784,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="
+    },
     "node_modules/fn.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
@@ -2335,6 +2933,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2347,6 +2976,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2354,6 +2988,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -2604,6 +3249,11 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
     "node_modules/kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
@@ -2642,6 +3292,11 @@
       "engines": {
         "node": ">= 12.0.0"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -2693,6 +3348,17 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2819,6 +3485,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -2848,6 +3522,45 @@
       "dependencies": {
         "fn.name": "1.x.x"
       }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "hasInstallScript": true,
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.3"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.25.0-dev.20260327-722743c0e2",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.25.0-dev.20260327-722743c0e2.tgz",
+      "integrity": "sha512-8PXdZy4Ekhg10CLg+cFFt39b4tFDGMRJB6lGjnQL6eA+2boUQYDymZ0gtxiS+H6oIWoCjQp/ziyirvFbaFKfiw==",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.24.0-dev.20251116-b39e144322",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="
     },
     "node_modules/open": {
       "version": "10.1.2",
@@ -2948,6 +3661,11 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
+    },
     "node_modules/postcss": {
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
@@ -2999,6 +3717,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -3205,6 +3946,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -3300,6 +4057,22 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+    },
     "node_modules/send": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
@@ -3320,6 +4093,20 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serve-handler": {
@@ -3411,6 +4198,49 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3544,6 +4374,11 @@
         "debug": "^4.3.7",
         "rxjs": "^7.8.1"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -3700,6 +4535,17 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.14.4",
+    "@huggingface/transformers": "^4.0.1",
     "@modelcontextprotocol/inspector": "^0.14.3",
     "@modelcontextprotocol/sdk": "^1.13.0",
     "@types/sanitize-html": "^2.16.0",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -86,6 +86,10 @@ const EnvSchema = z.object({
   // --- Obsidian Specific Config ---
   OBSIDIAN_API_KEY: z.string().min(1, "OBSIDIAN_API_KEY cannot be empty"),
   OBSIDIAN_BASE_URL: z.string().url().default("http://127.0.0.1:27123"),
+  OBSIDIAN_OMNISEARCH_BASE_URL: z
+    .string()
+    .url()
+    .default("http://127.0.0.1:51361"),
   OBSIDIAN_VERIFY_SSL: z
     .string()
     .transform((val) => val.toLowerCase() === "true")
@@ -210,6 +214,7 @@ export const config = {
   oauthJwksUri: env.OAUTH_JWKS_URI,
   obsidianApiKey: env.OBSIDIAN_API_KEY,
   obsidianBaseUrl: env.OBSIDIAN_BASE_URL,
+  obsidianOmnisearchBaseUrl: env.OBSIDIAN_OMNISEARCH_BASE_URL,
   obsidianVerifySsl: env.OBSIDIAN_VERIFY_SSL,
   obsidianCacheRefreshIntervalMin: env.OBSIDIAN_CACHE_REFRESH_INTERVAL_MIN,
   obsidianEnableCache: env.OBSIDIAN_ENABLE_CACHE,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -90,6 +90,11 @@ const EnvSchema = z.object({
     .string()
     .url()
     .default("http://127.0.0.1:51361"),
+  OBSIDIAN_VAULT_PATH: z.string().optional(),
+  SMART_CONNECTIONS_MODEL: z.string().default("TaylorAI/bge-micro-v2"),
+  SMART_CONNECTIONS_STORED_MODEL: z
+    .string()
+    .default("TaylorAI/bge-micro-v2"),
   OBSIDIAN_VERIFY_SSL: z
     .string()
     .transform((val) => val.toLowerCase() === "true")
@@ -215,6 +220,9 @@ export const config = {
   obsidianApiKey: env.OBSIDIAN_API_KEY,
   obsidianBaseUrl: env.OBSIDIAN_BASE_URL,
   obsidianOmnisearchBaseUrl: env.OBSIDIAN_OMNISEARCH_BASE_URL,
+  obsidianVaultPath: env.OBSIDIAN_VAULT_PATH,
+  smartConnectionsModel: env.SMART_CONNECTIONS_MODEL,
+  smartConnectionsStoredModel: env.SMART_CONNECTIONS_STORED_MODEL,
   obsidianVerifySsl: env.OBSIDIAN_VERIFY_SSL,
   obsidianCacheRefreshIntervalMin: env.OBSIDIAN_CACHE_REFRESH_INTERVAL_MIN,
   obsidianEnableCache: env.OBSIDIAN_ENABLE_CACHE,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { logger, McpLogLevel } from "./utils/internal/logger.js"; // Import logg
 import { ObsidianRestApiService } from "./services/obsidianRestAPI/index.js";
 import { VaultCacheService } from "./services/obsidianRestAPI/vaultCache/index.js"; // Import VaultCacheService
 import { OmnisearchService } from "./services/omnisearch/index.js";
+import { SmartConnectionsService } from "./services/smartConnections/index.js";
 
 /**
  * The main MCP server instance (only stored globally for stdio shutdown).
@@ -258,6 +259,24 @@ const start = async () => {
       startupContext,
     );
 
+    let smartConnectionsService: SmartConnectionsService | undefined;
+    if (config.obsidianVaultPath) {
+      smartConnectionsService = new SmartConnectionsService(
+        config.obsidianVaultPath,
+        config.smartConnectionsModel,
+        config.smartConnectionsStoredModel,
+      );
+      logger.info(
+        `Smart Connections service instantiated (vaultPath: ${config.obsidianVaultPath}, model: ${config.smartConnectionsModel}, storedModel: ${config.smartConnectionsStoredModel}).`,
+        startupContext,
+      );
+    } else {
+      logger.info(
+        "OBSIDIAN_VAULT_PATH not set; Smart Connections tools will be disabled.",
+        startupContext,
+      );
+    }
+
     logger.info("Shared services instantiated.", startupContext);
     // --- End Service Instantiation ---
 
@@ -274,6 +293,7 @@ const start = async () => {
       obsidianService,
       vaultCacheService,
       omnisearchService,
+      smartConnectionsService,
     );
 
     if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { logger, McpLogLevel } from "./utils/internal/logger.js"; // Import logg
 // Import Services
 import { ObsidianRestApiService } from "./services/obsidianRestAPI/index.js";
 import { VaultCacheService } from "./services/obsidianRestAPI/vaultCache/index.js"; // Import VaultCacheService
+import { OmnisearchService } from "./services/omnisearch/index.js";
 
 /**
  * The main MCP server instance (only stored globally for stdio shutdown).
@@ -248,6 +249,15 @@ const start = async () => {
     } else {
       logger.info("Vault cache is disabled by configuration.", startupContext);
     }
+
+    const omnisearchService = new OmnisearchService(
+      config.obsidianOmnisearchBaseUrl,
+    );
+    logger.info(
+      `Omnisearch service instantiated (baseUrl: ${config.obsidianOmnisearchBaseUrl}).`,
+      startupContext,
+    );
+
     logger.info("Shared services instantiated.", startupContext);
     // --- End Service Instantiation ---
 
@@ -263,6 +273,7 @@ const start = async () => {
     const serverOrHttpInstance = await initializeAndStartServer(
       obsidianService,
       vaultCacheService,
+      omnisearchService,
     );
 
     if (

--- a/src/mcp-server/server.ts
+++ b/src/mcp-server/server.ts
@@ -24,10 +24,13 @@ import { ErrorHandler, logger, requestContextService } from "../utils/index.js";
 import { ObsidianRestApiService } from "../services/obsidianRestAPI/index.js";
 // Import the Vault Cache service
 import { VaultCacheService } from "../services/obsidianRestAPI/vaultCache/index.js";
+// Import the Omnisearch service
+import { OmnisearchService } from "../services/omnisearch/index.js";
 // Import registration functions for specific resources and tools.
 import { registerObsidianDeleteNoteTool } from "./tools/obsidianDeleteNoteTool/index.js";
 import { registerObsidianGlobalSearchTool } from "./tools/obsidianGlobalSearchTool/index.js";
 import { registerObsidianListNotesTool } from "./tools/obsidianListNotesTool/index.js";
+import { registerObsidianOmnisearchTool } from "./tools/obsidianOmnisearchTool/index.js";
 import { registerObsidianReadNoteTool } from "./tools/obsidianReadNoteTool/index.js";
 import { registerObsidianSearchReplaceTool } from "./tools/obsidianSearchReplaceTool/index.js";
 import { registerObsidianUpdateNoteTool } from "./tools/obsidianUpdateNoteTool/index.js";
@@ -61,6 +64,7 @@ import { connectStdioTransport } from "./transports/stdioTransport.js";
 async function createMcpServerInstance(
   obsidianService: ObsidianRestApiService,
   vaultCacheService: VaultCacheService | undefined,
+  omnisearchService: OmnisearchService,
 ): Promise<McpServer> {
   const context = requestContextService.createRequestContext({
     operation: "createMcpServerInstance",
@@ -141,6 +145,7 @@ async function createMcpServerInstance(
       obsidianService,
       vaultCacheService,
     );
+    await registerObsidianOmnisearchTool(server, omnisearchService);
 
     logger.info("Resources and tools registered successfully", context);
 
@@ -197,6 +202,7 @@ async function createMcpServerInstance(
 async function startTransport(
   obsidianService: ObsidianRestApiService,
   vaultCacheService: VaultCacheService | undefined,
+  omnisearchService: OmnisearchService,
 ): Promise<McpServer | ServerType | void> {
   const transportType = config.mcpTransportType;
   const context = requestContextService.createRequestContext({
@@ -213,7 +219,11 @@ async function startTransport(
     // For HTTP, startHttpTransport manages its own lifecycle and server instances per session.
     // It needs a factory function to create new McpServer instances, passing along the shared services.
     const mcpServerFactory = async () =>
-      createMcpServerInstance(obsidianService, vaultCacheService);
+      createMcpServerInstance(
+        obsidianService,
+        vaultCacheService,
+        omnisearchService,
+      );
     const httpServerInstance = await startHttpTransport(
       mcpServerFactory,
       context,
@@ -229,6 +239,7 @@ async function startTransport(
     const server = await createMcpServerInstance(
       obsidianService,
       vaultCacheService,
+      omnisearchService,
     );
     logger.debug("Delegating to connectStdioTransport...", context);
     await connectStdioTransport(server, context);
@@ -261,6 +272,7 @@ async function startTransport(
 export async function initializeAndStartServer(
   obsidianService: ObsidianRestApiService,
   vaultCacheService: VaultCacheService | undefined,
+  omnisearchService: OmnisearchService,
 ): Promise<void | McpServer | ServerType> {
   const context = requestContextService.createRequestContext({
     operation: "initializeAndStartServer",
@@ -278,7 +290,11 @@ export async function initializeAndStartServer(
     );
 
     // Initiate the transport setup based on configuration, passing shared services.
-    const result = await startTransport(obsidianService, vaultCacheService);
+    const result = await startTransport(
+      obsidianService,
+      vaultCacheService,
+      omnisearchService,
+    );
     logger.info(
       "MCP Server initialization sequence completed successfully.",
       context,

--- a/src/mcp-server/server.ts
+++ b/src/mcp-server/server.ts
@@ -26,13 +26,18 @@ import { ObsidianRestApiService } from "../services/obsidianRestAPI/index.js";
 import { VaultCacheService } from "../services/obsidianRestAPI/vaultCache/index.js";
 // Import the Omnisearch service
 import { OmnisearchService } from "../services/omnisearch/index.js";
+// Import the Smart Connections service
+import { SmartConnectionsService } from "../services/smartConnections/index.js";
 // Import registration functions for specific resources and tools.
+import { registerObsidianContextBlocksTool } from "./tools/obsidianContextBlocksTool/index.js";
 import { registerObsidianDeleteNoteTool } from "./tools/obsidianDeleteNoteTool/index.js";
+import { registerObsidianFindRelatedTool } from "./tools/obsidianFindRelatedTool/index.js";
 import { registerObsidianGlobalSearchTool } from "./tools/obsidianGlobalSearchTool/index.js";
 import { registerObsidianListNotesTool } from "./tools/obsidianListNotesTool/index.js";
 import { registerObsidianOmnisearchTool } from "./tools/obsidianOmnisearchTool/index.js";
 import { registerObsidianReadNoteTool } from "./tools/obsidianReadNoteTool/index.js";
 import { registerObsidianSearchReplaceTool } from "./tools/obsidianSearchReplaceTool/index.js";
+import { registerObsidianSemanticSearchTool } from "./tools/obsidianSemanticSearchTool/index.js";
 import { registerObsidianUpdateNoteTool } from "./tools/obsidianUpdateNoteTool/index.js";
 import { registerObsidianManageFrontmatterTool } from "./tools/obsidianManageFrontmatterTool/index.js";
 import { registerObsidianManageTagsTool } from "./tools/obsidianManageTagsTool/index.js";
@@ -65,6 +70,7 @@ async function createMcpServerInstance(
   obsidianService: ObsidianRestApiService,
   vaultCacheService: VaultCacheService | undefined,
   omnisearchService: OmnisearchService,
+  smartConnectionsService: SmartConnectionsService | undefined,
 ): Promise<McpServer> {
   const context = requestContextService.createRequestContext({
     operation: "createMcpServerInstance",
@@ -147,6 +153,17 @@ async function createMcpServerInstance(
     );
     await registerObsidianOmnisearchTool(server, omnisearchService);
 
+    if (smartConnectionsService) {
+      await registerObsidianSemanticSearchTool(server, smartConnectionsService);
+      await registerObsidianFindRelatedTool(server, smartConnectionsService);
+      await registerObsidianContextBlocksTool(server, smartConnectionsService);
+    } else {
+      logger.warning(
+        "Skipping Smart Connections tools (obsidian_semantic_search, obsidian_find_related, obsidian_context_blocks) because OBSIDIAN_VAULT_PATH is not set.",
+        context,
+      );
+    }
+
     logger.info("Resources and tools registered successfully", context);
 
     if (vaultCacheService) {
@@ -203,6 +220,7 @@ async function startTransport(
   obsidianService: ObsidianRestApiService,
   vaultCacheService: VaultCacheService | undefined,
   omnisearchService: OmnisearchService,
+  smartConnectionsService: SmartConnectionsService | undefined,
 ): Promise<McpServer | ServerType | void> {
   const transportType = config.mcpTransportType;
   const context = requestContextService.createRequestContext({
@@ -223,6 +241,7 @@ async function startTransport(
         obsidianService,
         vaultCacheService,
         omnisearchService,
+        smartConnectionsService,
       );
     const httpServerInstance = await startHttpTransport(
       mcpServerFactory,
@@ -240,6 +259,7 @@ async function startTransport(
       obsidianService,
       vaultCacheService,
       omnisearchService,
+      smartConnectionsService,
     );
     logger.debug("Delegating to connectStdioTransport...", context);
     await connectStdioTransport(server, context);
@@ -273,6 +293,7 @@ export async function initializeAndStartServer(
   obsidianService: ObsidianRestApiService,
   vaultCacheService: VaultCacheService | undefined,
   omnisearchService: OmnisearchService,
+  smartConnectionsService: SmartConnectionsService | undefined,
 ): Promise<void | McpServer | ServerType> {
   const context = requestContextService.createRequestContext({
     operation: "initializeAndStartServer",
@@ -294,6 +315,7 @@ export async function initializeAndStartServer(
       obsidianService,
       vaultCacheService,
       omnisearchService,
+      smartConnectionsService,
     );
     logger.info(
       "MCP Server initialization sequence completed successfully.",

--- a/src/mcp-server/tools/obsidianContextBlocksTool/index.ts
+++ b/src/mcp-server/tools/obsidianContextBlocksTool/index.ts
@@ -1,0 +1,1 @@
+export { registerObsidianContextBlocksTool } from "./registration.js";

--- a/src/mcp-server/tools/obsidianContextBlocksTool/logic.ts
+++ b/src/mcp-server/tools/obsidianContextBlocksTool/logic.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import {
+  SemanticBlockHit,
+  SmartConnectionsService,
+} from "../../../services/smartConnections/index.js";
+import {
+  logger,
+  RequestContext,
+  sanitizeInputForLogging,
+} from "../../../utils/index.js";
+
+const ObsidianContextBlocksInputSchema = z
+  .object({
+    query: z
+      .string()
+      .min(1)
+      .describe(
+        "Natural-language query describing what context you need. The server returns the most semantically relevant block-level chunks with their text, ideal for RAG.",
+      ),
+    maxBlocks: z
+      .number()
+      .int()
+      .positive()
+      .max(50)
+      .optional()
+      .default(5)
+      .describe("Maximum number of blocks to return. Defaults to 5."),
+    minSimilarity: z
+      .number()
+      .min(0)
+      .max(1)
+      .optional()
+      .default(0.4)
+      .describe(
+        "Minimum cosine similarity threshold. Defaults to 0.4 — higher than semantic_search because block-level embeddings are noisier.",
+      ),
+  })
+  .describe(
+    "Get the best block-level context for a query from Smart Connections embeddings. Returns actual text content suitable for RAG-style LLM context assembly.",
+  );
+
+export const ObsidianContextBlocksInputSchemaShape =
+  ObsidianContextBlocksInputSchema.shape;
+export type ObsidianContextBlocksInput = z.infer<
+  typeof ObsidianContextBlocksInputSchema
+>;
+
+export interface ObsidianContextBlocksResponse {
+  success: boolean;
+  message: string;
+  query: string;
+  returned: number;
+  blocks: SemanticBlockHit[];
+}
+
+export async function processObsidianContextBlocks(
+  params: ObsidianContextBlocksInput,
+  context: RequestContext,
+  smartConnectionsService: SmartConnectionsService,
+): Promise<ObsidianContextBlocksResponse> {
+  const operation = "processObsidianContextBlocks";
+  const opContext = { ...context, operation };
+  logger.info(
+    `Processing obsidian_context_blocks: "${params.query}"`,
+    { ...opContext, params: sanitizeInputForLogging(params) },
+  );
+
+  const blocks = await smartConnectionsService.getContextBlocks(
+    params.query,
+    params.maxBlocks,
+    params.minSimilarity,
+    opContext,
+  );
+
+  const stats = smartConnectionsService.stats();
+  return {
+    success: true,
+    message: `Returned ${blocks.length} block(s) over ${stats.blocks} embedded blocks (minSimilarity ${params.minSimilarity}, maxBlocks ${params.maxBlocks}).`,
+    query: params.query,
+    returned: blocks.length,
+    blocks,
+  };
+}

--- a/src/mcp-server/tools/obsidianContextBlocksTool/registration.ts
+++ b/src/mcp-server/tools/obsidianContextBlocksTool/registration.ts
@@ -1,0 +1,91 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SmartConnectionsService } from "../../../services/smartConnections/index.js";
+import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+import {
+  ErrorHandler,
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+import type {
+  ObsidianContextBlocksInput,
+  ObsidianContextBlocksResponse,
+} from "./logic.js";
+import {
+  ObsidianContextBlocksInputSchemaShape,
+  processObsidianContextBlocks,
+} from "./logic.js";
+
+export async function registerObsidianContextBlocksTool(
+  server: McpServer,
+  smartConnectionsService: SmartConnectionsService,
+): Promise<void> {
+  const toolName = "obsidian_context_blocks";
+  const toolDescription = `Get the best block-level text chunks for a query from Smart Connections embeddings. Returns actual text content, not just file references — ideal for RAG-style context assembly when you need the relevant passages inline rather than note paths.`;
+
+  const registrationContext: RequestContext =
+    requestContextService.createRequestContext({
+      operation: "RegisterObsidianContextBlocksTool",
+      toolName,
+      module: "ObsidianContextBlocksRegistration",
+    });
+
+  await ErrorHandler.tryCatch(
+    async () => {
+      server.tool(
+        toolName,
+        toolDescription,
+        ObsidianContextBlocksInputSchemaShape,
+        async (params: ObsidianContextBlocksInput): Promise<any> => {
+          const handlerContext: RequestContext =
+            requestContextService.createRequestContext({
+              operation: "HandleObsidianContextBlocksRequest",
+              toolName,
+              paramsSummary: {
+                query: params.query,
+                maxBlocks: params.maxBlocks,
+                minSimilarity: params.minSimilarity,
+              },
+            });
+          return await ErrorHandler.tryCatch(
+            async () => {
+              const response: ObsidianContextBlocksResponse =
+                await processObsidianContextBlocks(
+                  params,
+                  handlerContext,
+                  smartConnectionsService,
+                );
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify(response, null, 2),
+                  },
+                ],
+                isError: false,
+              };
+            },
+            {
+              operation: `executing tool ${toolName}`,
+              context: handlerContext,
+              errorCode: BaseErrorCode.INTERNAL_ERROR,
+            },
+          );
+        },
+      );
+      logger.info(`Tool registered successfully: ${toolName}`, registrationContext);
+    },
+    {
+      operation: `registering tool ${toolName}`,
+      context: registrationContext,
+      errorCode: BaseErrorCode.INTERNAL_ERROR,
+      errorMapper: (error: unknown) =>
+        new McpError(
+          error instanceof McpError ? error.code : BaseErrorCode.INTERNAL_ERROR,
+          `Failed to register tool '${toolName}': ${error instanceof Error ? error.message : "Unknown error"}`,
+          { ...registrationContext },
+        ),
+      critical: true,
+    },
+  );
+}

--- a/src/mcp-server/tools/obsidianFindRelatedTool/index.ts
+++ b/src/mcp-server/tools/obsidianFindRelatedTool/index.ts
@@ -1,0 +1,1 @@
+export { registerObsidianFindRelatedTool } from "./registration.js";

--- a/src/mcp-server/tools/obsidianFindRelatedTool/logic.ts
+++ b/src/mcp-server/tools/obsidianFindRelatedTool/logic.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import {
+  SemanticHit,
+  SmartConnectionsService,
+} from "../../../services/smartConnections/index.js";
+import {
+  logger,
+  RequestContext,
+  sanitizeInputForLogging,
+} from "../../../utils/index.js";
+
+const ObsidianFindRelatedInputSchema = z
+  .object({
+    filePath: z
+      .string()
+      .min(1)
+      .describe(
+        "Vault-relative path of the source note (e.g. 'papers/2603.16417.md'). The file must have been embedded by Smart Connections.",
+      ),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(100)
+      .optional()
+      .default(10)
+      .describe("Maximum number of related notes to return. Defaults to 10."),
+  })
+  .describe(
+    "Find notes semantically related to a specific source note, using Smart Connections embeddings. Equivalent to the Smart Connections sidebar's 'related notes' view.",
+  );
+
+export const ObsidianFindRelatedInputSchemaShape =
+  ObsidianFindRelatedInputSchema.shape;
+export type ObsidianFindRelatedInput = z.infer<
+  typeof ObsidianFindRelatedInputSchema
+>;
+
+export interface ObsidianFindRelatedResponse {
+  success: boolean;
+  message: string;
+  sourceFile: string;
+  returned: number;
+  results: SemanticHit[];
+}
+
+export async function processObsidianFindRelated(
+  params: ObsidianFindRelatedInput,
+  context: RequestContext,
+  smartConnectionsService: SmartConnectionsService,
+): Promise<ObsidianFindRelatedResponse> {
+  const operation = "processObsidianFindRelated";
+  const opContext = { ...context, operation };
+  logger.info(
+    `Processing obsidian_find_related: "${params.filePath}"`,
+    { ...opContext, params: sanitizeInputForLogging(params) },
+  );
+
+  const results = await smartConnectionsService.findRelated(
+    params.filePath,
+    params.limit,
+    opContext,
+  );
+
+  return {
+    success: true,
+    message: `Found ${results.length} related note(s) for '${params.filePath}'.`,
+    sourceFile: params.filePath,
+    returned: results.length,
+    results,
+  };
+}

--- a/src/mcp-server/tools/obsidianFindRelatedTool/registration.ts
+++ b/src/mcp-server/tools/obsidianFindRelatedTool/registration.ts
@@ -1,0 +1,90 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SmartConnectionsService } from "../../../services/smartConnections/index.js";
+import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+import {
+  ErrorHandler,
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+import type {
+  ObsidianFindRelatedInput,
+  ObsidianFindRelatedResponse,
+} from "./logic.js";
+import {
+  ObsidianFindRelatedInputSchemaShape,
+  processObsidianFindRelated,
+} from "./logic.js";
+
+export async function registerObsidianFindRelatedTool(
+  server: McpServer,
+  smartConnectionsService: SmartConnectionsService,
+): Promise<void> {
+  const toolName = "obsidian_find_related";
+  const toolDescription = `Find notes semantically related to a specific source note using Smart Connections embeddings. Equivalent to Smart Connections' in-Obsidian sidebar. Use this when you have a specific file and want to discover other notes on similar topics, rather than searching with free-form text.`;
+
+  const registrationContext: RequestContext =
+    requestContextService.createRequestContext({
+      operation: "RegisterObsidianFindRelatedTool",
+      toolName,
+      module: "ObsidianFindRelatedRegistration",
+    });
+
+  await ErrorHandler.tryCatch(
+    async () => {
+      server.tool(
+        toolName,
+        toolDescription,
+        ObsidianFindRelatedInputSchemaShape,
+        async (params: ObsidianFindRelatedInput): Promise<any> => {
+          const handlerContext: RequestContext =
+            requestContextService.createRequestContext({
+              operation: "HandleObsidianFindRelatedRequest",
+              toolName,
+              paramsSummary: {
+                filePath: params.filePath,
+                limit: params.limit,
+              },
+            });
+          return await ErrorHandler.tryCatch(
+            async () => {
+              const response: ObsidianFindRelatedResponse =
+                await processObsidianFindRelated(
+                  params,
+                  handlerContext,
+                  smartConnectionsService,
+                );
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify(response, null, 2),
+                  },
+                ],
+                isError: false,
+              };
+            },
+            {
+              operation: `executing tool ${toolName}`,
+              context: handlerContext,
+              errorCode: BaseErrorCode.INTERNAL_ERROR,
+            },
+          );
+        },
+      );
+      logger.info(`Tool registered successfully: ${toolName}`, registrationContext);
+    },
+    {
+      operation: `registering tool ${toolName}`,
+      context: registrationContext,
+      errorCode: BaseErrorCode.INTERNAL_ERROR,
+      errorMapper: (error: unknown) =>
+        new McpError(
+          error instanceof McpError ? error.code : BaseErrorCode.INTERNAL_ERROR,
+          `Failed to register tool '${toolName}': ${error instanceof Error ? error.message : "Unknown error"}`,
+          { ...registrationContext },
+        ),
+      critical: true,
+    },
+  );
+}

--- a/src/mcp-server/tools/obsidianOmnisearchTool/index.ts
+++ b/src/mcp-server/tools/obsidianOmnisearchTool/index.ts
@@ -1,0 +1,1 @@
+export { registerObsidianOmnisearchTool } from "./registration.js";

--- a/src/mcp-server/tools/obsidianOmnisearchTool/logic.ts
+++ b/src/mcp-server/tools/obsidianOmnisearchTool/logic.ts
@@ -1,0 +1,133 @@
+import { z } from "zod";
+import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+import {
+  OmnisearchHit,
+  OmnisearchService,
+} from "../../../services/omnisearch/index.js";
+import {
+  logger,
+  RequestContext,
+  sanitizeInputForLogging,
+} from "../../../utils/index.js";
+
+const ObsidianOmnisearchInputSchema = z
+  .object({
+    query: z
+      .string()
+      .min(1)
+      .describe(
+        "Search query. Omnisearch supports fuzzy matching, tokenization, and multi-word queries with default AND semantics.",
+      ),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(200)
+      .optional()
+      .default(20)
+      .describe(
+        "Maximum number of results to return (1-200). Defaults to 20.",
+      ),
+    maxMatchesPerFile: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .default(5)
+      .describe(
+        "Maximum match offsets to return per file. 0 drops match arrays entirely. Defaults to 5.",
+      ),
+    searchInPath: z
+      .string()
+      .optional()
+      .describe(
+        "Optional vault-relative path prefix to filter results by (e.g. 'papers/'). Applied client-side after Omnisearch returns hits.",
+      ),
+  })
+  .describe(
+    "Performs fast indexed full-text search across the Obsidian vault using the Omnisearch plugin's HTTP API. Supports fuzzy matching and tokenization. Much faster than obsidian_global_search for large vaults.",
+  );
+
+export const ObsidianOmnisearchInputSchemaShape =
+  ObsidianOmnisearchInputSchema.shape;
+export type ObsidianOmnisearchInput = z.infer<
+  typeof ObsidianOmnisearchInputSchema
+>;
+
+export interface ObsidianOmnisearchResult {
+  path: string;
+  basename: string;
+  score: number;
+  foundWords: string[];
+  matches: { match: string; offset: number }[];
+  excerpt?: string;
+}
+
+export interface ObsidianOmnisearchResponse {
+  success: boolean;
+  message: string;
+  query: string;
+  totalHits: number;
+  returned: number;
+  results: ObsidianOmnisearchResult[];
+}
+
+export async function processObsidianOmnisearch(
+  params: ObsidianOmnisearchInput,
+  context: RequestContext,
+  omnisearchService: OmnisearchService,
+): Promise<ObsidianOmnisearchResponse> {
+  const operation = "processObsidianOmnisearch";
+  const opContext = { ...context, operation };
+  logger.info(
+    `Processing obsidian_omnisearch: "${params.query}"`,
+    { ...opContext, params: sanitizeInputForLogging(params) },
+  );
+
+  let hits: OmnisearchHit[];
+  try {
+    hits = await omnisearchService.search(params.query, opContext);
+  } catch (err) {
+    if (err instanceof McpError) throw err;
+    throw new McpError(
+      BaseErrorCode.SERVICE_UNAVAILABLE,
+      `Omnisearch query failed: ${err instanceof Error ? err.message : String(err)}`,
+      opContext,
+    );
+  }
+
+  const pathPrefix = params.searchInPath
+    ? params.searchInPath.replace(/^\/+|\/+$/g, "") + "/"
+    : "";
+
+  const filtered = pathPrefix
+    ? hits.filter((h) => h.path.startsWith(pathPrefix))
+    : hits;
+
+  const totalHits = filtered.length;
+  const limited = filtered.slice(0, params.limit);
+
+  const results: ObsidianOmnisearchResult[] = limited.map((h) => ({
+    path: h.path,
+    basename: h.basename,
+    score: h.score,
+    foundWords: h.foundWords,
+    matches: params.maxMatchesPerFile > 0
+      ? h.matches.slice(0, params.maxMatchesPerFile)
+      : [],
+    excerpt: h.excerpt,
+  }));
+
+  const message = `Omnisearch returned ${hits.length} hits${
+    pathPrefix ? ` (${totalHits} after path filter '${pathPrefix}')` : ""
+  }. Returning ${results.length} result(s), limit ${params.limit}, max matches per file ${params.maxMatchesPerFile}.`;
+
+  return {
+    success: true,
+    message,
+    query: params.query,
+    totalHits,
+    returned: results.length,
+    results,
+  };
+}

--- a/src/mcp-server/tools/obsidianOmnisearchTool/registration.ts
+++ b/src/mcp-server/tools/obsidianOmnisearchTool/registration.ts
@@ -1,0 +1,104 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { OmnisearchService } from "../../../services/omnisearch/index.js";
+import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+import {
+  ErrorHandler,
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+import type {
+  ObsidianOmnisearchInput,
+  ObsidianOmnisearchResponse,
+} from "./logic.js";
+import {
+  ObsidianOmnisearchInputSchemaShape,
+  processObsidianOmnisearch,
+} from "./logic.js";
+
+export async function registerObsidianOmnisearchTool(
+  server: McpServer,
+  omnisearchService: OmnisearchService,
+): Promise<void> {
+  const toolName = "obsidian_omnisearch";
+  const toolDescription = `Performs fast indexed full-text search across the Obsidian vault using the Omnisearch plugin's HTTP API. Supports fuzzy matching, tokenization, and multi-word queries. Returns hits sorted by relevance score, with match offsets and the words that triggered the match. Much faster than obsidian_global_search for large vaults. Requires the Omnisearch community plugin with its HTTP server enabled.`;
+
+  const registrationContext: RequestContext =
+    requestContextService.createRequestContext({
+      operation: "RegisterObsidianOmnisearchTool",
+      toolName,
+      module: "ObsidianOmnisearchRegistration",
+    });
+
+  logger.info(`Attempting to register tool: ${toolName}`, registrationContext);
+
+  await ErrorHandler.tryCatch(
+    async () => {
+      server.tool(
+        toolName,
+        toolDescription,
+        ObsidianOmnisearchInputSchemaShape,
+        async (params: ObsidianOmnisearchInput): Promise<any> => {
+          const handlerContext: RequestContext =
+            requestContextService.createRequestContext({
+              operation: "HandleObsidianOmnisearchRequest",
+              toolName,
+              paramsSummary: {
+                query: params.query,
+                limit: params.limit,
+                maxMatchesPerFile: params.maxMatchesPerFile,
+                searchInPath: params.searchInPath,
+              },
+            });
+          logger.debug(`Handling '${toolName}' request`, handlerContext);
+
+          return await ErrorHandler.tryCatch(
+            async () => {
+              const response: ObsidianOmnisearchResponse =
+                await processObsidianOmnisearch(
+                  params,
+                  handlerContext,
+                  omnisearchService,
+                );
+              logger.debug(
+                `'${toolName}' processed successfully`,
+                handlerContext,
+              );
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify(response, null, 2),
+                  },
+                ],
+                isError: false,
+              };
+            },
+            {
+              operation: `executing tool ${toolName}`,
+              context: handlerContext,
+              errorCode: BaseErrorCode.INTERNAL_ERROR,
+            },
+          );
+        },
+      );
+
+      logger.info(
+        `Tool registered successfully: ${toolName}`,
+        registrationContext,
+      );
+    },
+    {
+      operation: `registering tool ${toolName}`,
+      context: registrationContext,
+      errorCode: BaseErrorCode.INTERNAL_ERROR,
+      errorMapper: (error: unknown) =>
+        new McpError(
+          error instanceof McpError ? error.code : BaseErrorCode.INTERNAL_ERROR,
+          `Failed to register tool '${toolName}': ${error instanceof Error ? error.message : "Unknown error"}`,
+          { ...registrationContext },
+        ),
+      critical: true,
+    },
+  );
+}

--- a/src/mcp-server/tools/obsidianSemanticSearchTool/index.ts
+++ b/src/mcp-server/tools/obsidianSemanticSearchTool/index.ts
@@ -1,0 +1,1 @@
+export { registerObsidianSemanticSearchTool } from "./registration.js";

--- a/src/mcp-server/tools/obsidianSemanticSearchTool/logic.ts
+++ b/src/mcp-server/tools/obsidianSemanticSearchTool/logic.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import {
+  SemanticHit,
+  SmartConnectionsService,
+} from "../../../services/smartConnections/index.js";
+import {
+  logger,
+  RequestContext,
+  sanitizeInputForLogging,
+} from "../../../utils/index.js";
+
+const ObsidianSemanticSearchInputSchema = z
+  .object({
+    query: z
+      .string()
+      .min(1)
+      .describe(
+        "Natural-language query. The server encodes it with the Smart Connections embedding model and returns notes whose stored vectors are most similar.",
+      ),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(100)
+      .optional()
+      .default(10)
+      .describe("Maximum number of results to return. Defaults to 10."),
+    minSimilarity: z
+      .number()
+      .min(0)
+      .max(1)
+      .optional()
+      .default(0.3)
+      .describe(
+        "Minimum cosine similarity threshold, 0-1. Defaults to 0.3. Lower returns more results; higher returns only tight matches.",
+      ),
+  })
+  .describe(
+    "Semantic search over the Obsidian vault using Smart Connections embeddings. Finds notes by meaning rather than exact keywords. Requires the Smart Connections community plugin with embeddings already generated.",
+  );
+
+export const ObsidianSemanticSearchInputSchemaShape =
+  ObsidianSemanticSearchInputSchema.shape;
+export type ObsidianSemanticSearchInput = z.infer<
+  typeof ObsidianSemanticSearchInputSchema
+>;
+
+export interface ObsidianSemanticSearchResponse {
+  success: boolean;
+  message: string;
+  query: string;
+  returned: number;
+  results: SemanticHit[];
+}
+
+export async function processObsidianSemanticSearch(
+  params: ObsidianSemanticSearchInput,
+  context: RequestContext,
+  smartConnectionsService: SmartConnectionsService,
+): Promise<ObsidianSemanticSearchResponse> {
+  const operation = "processObsidianSemanticSearch";
+  const opContext = { ...context, operation };
+  logger.info(
+    `Processing obsidian_semantic_search: "${params.query}"`,
+    { ...opContext, params: sanitizeInputForLogging(params) },
+  );
+
+  const results = await smartConnectionsService.semanticSearch(
+    params.query,
+    params.limit,
+    params.minSimilarity,
+    opContext,
+  );
+
+  const stats = smartConnectionsService.stats();
+  const message = `Semantic search returned ${results.length} result(s) over ${stats.sources} embedded source notes (minSimilarity ${params.minSimilarity}, limit ${params.limit}).`;
+
+  return {
+    success: true,
+    message,
+    query: params.query,
+    returned: results.length,
+    results,
+  };
+}

--- a/src/mcp-server/tools/obsidianSemanticSearchTool/registration.ts
+++ b/src/mcp-server/tools/obsidianSemanticSearchTool/registration.ts
@@ -1,0 +1,91 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SmartConnectionsService } from "../../../services/smartConnections/index.js";
+import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+import {
+  ErrorHandler,
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+import type {
+  ObsidianSemanticSearchInput,
+  ObsidianSemanticSearchResponse,
+} from "./logic.js";
+import {
+  ObsidianSemanticSearchInputSchemaShape,
+  processObsidianSemanticSearch,
+} from "./logic.js";
+
+export async function registerObsidianSemanticSearchTool(
+  server: McpServer,
+  smartConnectionsService: SmartConnectionsService,
+): Promise<void> {
+  const toolName = "obsidian_semantic_search";
+  const toolDescription = `Semantic search across the Obsidian vault using Smart Connections embeddings. Finds notes by meaning, not exact keywords. Best for conceptual queries ("what have I written about attention mechanisms?") rather than lexical ones. Requires the Smart Connections community plugin to have generated embeddings first.`;
+
+  const registrationContext: RequestContext =
+    requestContextService.createRequestContext({
+      operation: "RegisterObsidianSemanticSearchTool",
+      toolName,
+      module: "ObsidianSemanticSearchRegistration",
+    });
+
+  await ErrorHandler.tryCatch(
+    async () => {
+      server.tool(
+        toolName,
+        toolDescription,
+        ObsidianSemanticSearchInputSchemaShape,
+        async (params: ObsidianSemanticSearchInput): Promise<any> => {
+          const handlerContext: RequestContext =
+            requestContextService.createRequestContext({
+              operation: "HandleObsidianSemanticSearchRequest",
+              toolName,
+              paramsSummary: {
+                query: params.query,
+                limit: params.limit,
+                minSimilarity: params.minSimilarity,
+              },
+            });
+          return await ErrorHandler.tryCatch(
+            async () => {
+              const response: ObsidianSemanticSearchResponse =
+                await processObsidianSemanticSearch(
+                  params,
+                  handlerContext,
+                  smartConnectionsService,
+                );
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify(response, null, 2),
+                  },
+                ],
+                isError: false,
+              };
+            },
+            {
+              operation: `executing tool ${toolName}`,
+              context: handlerContext,
+              errorCode: BaseErrorCode.INTERNAL_ERROR,
+            },
+          );
+        },
+      );
+      logger.info(`Tool registered successfully: ${toolName}`, registrationContext);
+    },
+    {
+      operation: `registering tool ${toolName}`,
+      context: registrationContext,
+      errorCode: BaseErrorCode.INTERNAL_ERROR,
+      errorMapper: (error: unknown) =>
+        new McpError(
+          error instanceof McpError ? error.code : BaseErrorCode.INTERNAL_ERROR,
+          `Failed to register tool '${toolName}': ${error instanceof Error ? error.message : "Unknown error"}`,
+          { ...registrationContext },
+        ),
+      critical: true,
+    },
+  );
+}

--- a/src/services/omnisearch/index.ts
+++ b/src/services/omnisearch/index.ts
@@ -1,0 +1,58 @@
+/**
+ * @module OmnisearchService
+ * Thin HTTP client for the Obsidian Omnisearch plugin's local HTTP API.
+ * Enabled in Obsidian via Omnisearch settings → "Enable HTTP server".
+ */
+
+import { BaseErrorCode, McpError } from "../../types-global/errors.js";
+import { logger, RequestContext } from "../../utils/index.js";
+
+export interface OmnisearchMatch {
+  match: string;
+  offset: number;
+}
+
+export interface OmnisearchHit {
+  score: number;
+  vault: string;
+  path: string;
+  basename: string;
+  foundWords: string[];
+  matches: OmnisearchMatch[];
+  excerpt?: string;
+}
+
+export class OmnisearchService {
+  constructor(private readonly baseUrl: string) {}
+
+  async search(
+    query: string,
+    context: RequestContext,
+  ): Promise<OmnisearchHit[]> {
+    const url = `${this.baseUrl.replace(/\/+$/, "")}/search?q=${encodeURIComponent(query)}`;
+    const operation = "OmnisearchService.search";
+    const opContext = { ...context, operation, url };
+
+    logger.debug(`Calling Omnisearch HTTP API: ${url}`, opContext);
+
+    let response: Response;
+    try {
+      response = await fetch(url);
+    } catch (err) {
+      const msg = `Omnisearch request failed: ${err instanceof Error ? err.message : String(err)}`;
+      logger.error(msg, err instanceof Error ? err : undefined, opContext);
+      throw new McpError(BaseErrorCode.SERVICE_UNAVAILABLE, msg, opContext);
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      const msg = `Omnisearch returned HTTP ${response.status} ${response.statusText}: ${body.slice(0, 200)}`;
+      logger.error(msg, opContext);
+      throw new McpError(BaseErrorCode.SERVICE_UNAVAILABLE, msg, opContext);
+    }
+
+    const body = (await response.json()) as OmnisearchHit[];
+    logger.debug(`Omnisearch returned ${body.length} hits`, opContext);
+    return body;
+  }
+}

--- a/src/services/smartConnections/index.ts
+++ b/src/services/smartConnections/index.ts
@@ -1,0 +1,302 @@
+/**
+ * @module SmartConnectionsService
+ * Reads and queries the Obsidian Smart Connections plugin's embedding cache
+ * at `<vault>/.smart-env/multi/*.ajson` and provides semantic search via a
+ * locally-loaded ONNX embedding model.
+ */
+
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { pipeline } from "@huggingface/transformers";
+import { BaseErrorCode, McpError } from "../../types-global/errors.js";
+import { logger, RequestContext } from "../../utils/index.js";
+
+export type EmbeddingKind = "source" | "block";
+
+export interface StoredEmbedding {
+  key: string;
+  path: string;
+  kind: EmbeddingKind;
+  vec: Float32Array;
+  text?: string;
+  lines?: number[];
+}
+
+export interface SemanticHit {
+  key: string;
+  path: string;
+  similarity: number;
+}
+
+export interface SemanticBlockHit extends SemanticHit {
+  text?: string;
+  lines?: number[];
+}
+
+type FeatureExtractor = (
+  text: string,
+  opts: { pooling: "mean"; normalize: boolean },
+) => Promise<{ data: Float32Array }>;
+
+export class SmartConnectionsService {
+  private embeddings: StoredEmbedding[] | null = null;
+  private embeddingsLoadedAt = 0;
+  private pipelinePromise: Promise<FeatureExtractor> | null = null;
+  private readonly storedModelName: string;
+
+  constructor(
+    private readonly vaultPath: string,
+    private readonly onnxModelName: string,
+    storedModelName?: string,
+  ) {
+    this.storedModelName = storedModelName ?? "TaylorAI/bge-micro-v2";
+  }
+
+  private async ensurePipeline(
+    context: RequestContext,
+  ): Promise<FeatureExtractor> {
+    if (!this.pipelinePromise) {
+      logger.info(
+        `Loading Smart Connections embedding model: ${this.onnxModelName}`,
+        context,
+      );
+      this.pipelinePromise = pipeline(
+        "feature-extraction",
+        this.onnxModelName,
+      ) as unknown as Promise<FeatureExtractor>;
+    }
+    return this.pipelinePromise;
+  }
+
+  async loadEmbeddings(
+    context: RequestContext,
+    opts: { force?: boolean } = {},
+  ): Promise<void> {
+    if (!opts.force && this.embeddings) return;
+
+    const multiDir = join(this.vaultPath, ".smart-env", "multi");
+    let files: string[];
+    try {
+      files = (await readdir(multiDir)).filter((f) => f.endsWith(".ajson"));
+    } catch (err) {
+      const msg = `Failed to read Smart Connections cache at ${multiDir}: ${err instanceof Error ? err.message : String(err)}. Is the Smart Connections plugin installed and has it embedded at least one note?`;
+      throw new McpError(BaseErrorCode.SERVICE_UNAVAILABLE, msg, context);
+    }
+
+    const loaded: StoredEmbedding[] = [];
+    let skipped = 0;
+    for (const file of files) {
+      const fullPath = join(multiDir, file);
+      try {
+        const content = await readFile(fullPath, "utf-8");
+        const entries = parseAjson(content);
+        for (const [key, raw] of Object.entries(entries)) {
+          const item = raw as Record<string, unknown>;
+          const embeddings = item.embeddings as
+            | Record<string, { vec?: number[] }>
+            | undefined;
+          const vecArray = embeddings?.[this.storedModelName]?.vec;
+          if (!vecArray || !Array.isArray(vecArray)) continue;
+
+          const vec = normalize(new Float32Array(vecArray));
+          const kind: EmbeddingKind = key.startsWith("smart_sources:")
+            ? "source"
+            : "block";
+          const storedPath = item.path as string | null | undefined;
+          const path =
+            storedPath && storedPath.length > 0
+              ? storedPath
+              : extractPathFromKey(key);
+          loaded.push({
+            key,
+            path,
+            kind,
+            vec,
+            text: (item.text as string | null | undefined) ?? undefined,
+            lines: item.lines as number[] | undefined,
+          });
+        }
+      } catch (err) {
+        skipped++;
+        logger.warning(
+          `Failed to parse Smart Connections cache file ${file}: ${err instanceof Error ? err.message : String(err)}`,
+          context,
+        );
+      }
+    }
+
+    this.embeddings = loaded;
+    this.embeddingsLoadedAt = Date.now();
+    logger.info(
+      `Smart Connections: loaded ${loaded.length} embeddings from ${files.length} files (${skipped} skipped)`,
+      context,
+    );
+  }
+
+  private async encodeQuery(
+    query: string,
+    context: RequestContext,
+  ): Promise<Float32Array> {
+    const extractor = await this.ensurePipeline(context);
+    const output = await extractor(query, { pooling: "mean", normalize: true });
+    return new Float32Array(output.data);
+  }
+
+  async semanticSearch(
+    query: string,
+    limit: number,
+    minSimilarity: number,
+    context: RequestContext,
+  ): Promise<SemanticHit[]> {
+    await this.loadEmbeddings(context);
+    const queryVec = await this.encodeQuery(query, context);
+
+    const results: SemanticHit[] = [];
+    for (const emb of this.embeddings!) {
+      if (emb.kind !== "source") continue;
+      const sim = dot(queryVec, emb.vec);
+      if (sim >= minSimilarity) {
+        results.push({ key: emb.key, path: emb.path, similarity: sim });
+      }
+    }
+    results.sort((a, b) => b.similarity - a.similarity);
+    return results.slice(0, limit);
+  }
+
+  async findRelated(
+    filePath: string,
+    limit: number,
+    context: RequestContext,
+  ): Promise<SemanticHit[]> {
+    await this.loadEmbeddings(context);
+    const targetKey = `smart_sources:${filePath}`;
+    const target = this.embeddings!.find((e) => e.key === targetKey);
+    if (!target) {
+      throw new McpError(
+        BaseErrorCode.NOT_FOUND,
+        `No Smart Connections embedding for '${filePath}'. The file may not exist in the vault or has not been embedded yet.`,
+        context,
+      );
+    }
+
+    const results: SemanticHit[] = [];
+    for (const emb of this.embeddings!) {
+      if (emb.kind !== "source" || emb.key === targetKey) continue;
+      const sim = dot(target.vec, emb.vec);
+      results.push({ key: emb.key, path: emb.path, similarity: sim });
+    }
+    results.sort((a, b) => b.similarity - a.similarity);
+    return results.slice(0, limit);
+  }
+
+  async getContextBlocks(
+    query: string,
+    maxBlocks: number,
+    minSimilarity: number,
+    context: RequestContext,
+  ): Promise<SemanticBlockHit[]> {
+    await this.loadEmbeddings(context);
+    const queryVec = await this.encodeQuery(query, context);
+
+    const candidates: SemanticBlockHit[] = [];
+    for (const emb of this.embeddings!) {
+      if (emb.kind !== "block") continue;
+      const sim = dot(queryVec, emb.vec);
+      if (sim >= minSimilarity) {
+        candidates.push({
+          key: emb.key,
+          path: emb.path,
+          similarity: sim,
+          text: emb.text,
+          lines: emb.lines,
+        });
+      }
+    }
+    candidates.sort((a, b) => b.similarity - a.similarity);
+    const top = candidates.slice(0, maxBlocks);
+
+    // Hydrate text from disk for blocks that don't have it cached.
+    const fileCache = new Map<string, string[]>();
+    for (const block of top) {
+      if (block.text || !block.path || !block.lines) continue;
+      try {
+        let lines = fileCache.get(block.path);
+        if (!lines) {
+          const full = await readFile(
+            join(this.vaultPath, block.path),
+            "utf-8",
+          );
+          lines = full.split("\n");
+          fileCache.set(block.path, lines);
+        }
+        const [start, end] = block.lines;
+        if (typeof start === "number" && typeof end === "number") {
+          block.text = lines.slice(start - 1, end).join("\n");
+        }
+      } catch (err) {
+        logger.warning(
+          `Failed to hydrate block text for ${block.path}: ${err instanceof Error ? err.message : String(err)}`,
+          context,
+        );
+      }
+    }
+
+    return top;
+  }
+
+  stats(): { loaded: boolean; sources: number; blocks: number; loadedAt: number } {
+    if (!this.embeddings) {
+      return { loaded: false, sources: 0, blocks: 0, loadedAt: 0 };
+    }
+    let sources = 0;
+    let blocks = 0;
+    for (const e of this.embeddings) {
+      if (e.kind === "source") sources++;
+      else blocks++;
+    }
+    return {
+      loaded: true,
+      sources,
+      blocks,
+      loadedAt: this.embeddingsLoadedAt,
+    };
+  }
+}
+
+function extractPathFromKey(key: string): string {
+  const prefix = key.startsWith("smart_sources:")
+    ? "smart_sources:"
+    : key.startsWith("smart_blocks:")
+      ? "smart_blocks:"
+      : "";
+  if (!prefix) return "";
+  const rest = key.slice(prefix.length);
+  const hashIdx = rest.indexOf("#");
+  return hashIdx >= 0 ? rest.slice(0, hashIdx) : rest;
+}
+
+function parseAjson(content: string): Record<string, unknown> {
+  const trimmed = content.trim();
+  if (!trimmed) return {};
+  if (trimmed.startsWith("{")) {
+    return JSON.parse(trimmed);
+  }
+  return JSON.parse("{" + trimmed.replace(/,\s*$/, "") + "}");
+}
+
+function normalize(v: Float32Array): Float32Array {
+  let s = 0;
+  for (let i = 0; i < v.length; i++) s += v[i] * v[i];
+  const n = Math.sqrt(s);
+  if (n === 0) return v;
+  const out = new Float32Array(v.length);
+  for (let i = 0; i < v.length; i++) out[i] = v[i] / n;
+  return out;
+}
+
+function dot(a: Float32Array, b: Float32Array): number {
+  let s = 0;
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) s += a[i] * b[i];
+  return s;
+}


### PR DESCRIPTION
Adds a new MCP tool backed by the Obsidian Omnisearch plugin's local HTTP server for fast indexed full-text search. Much faster than obsidian_global_search for large vaults, and returns Omnisearch's relevance scoring, matched word lists, and excerpts.

- src/services/omnisearch: thin HTTP client for the /search endpoint
- src/mcp-server/tools/obsidianOmnisearchTool: new tool with path-prefix filtering, result limiting, and per-file match caps
- src/config: new OBSIDIAN_OMNISEARCH_BASE_URL env var (defaults to http://127.0.0.1:51361)
- src/index.ts + src/mcp-server/server.ts: instantiate and wire the service through the startup chain

Requires the Omnisearch community plugin with its HTTP server enabled.