### PR TITLE
fix: add explicit type fields to JSON schema for Gemini CLI compatibility

### DIFF
--- a/src/mcp-server/tools/obsidianDeleteNoteTool/registration.ts
+++ b/src/mcp-server/tools/obsidianDeleteNoteTool/registration.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import {
   ObsidianRestApiService,
   VaultCacheService,
@@ -9,6 +10,7 @@ import {
   logger,
   RequestContext,
   requestContextService,
+  createJsonSchema,
 } from "../../../utils/index.js";
 // Import necessary types, schema, and logic function from the logic file
 import type {
@@ -60,10 +62,13 @@ export const registerObsidianDeleteNoteTool = async (
   await ErrorHandler.tryCatch(
     async () => {
       // Use the high-level SDK method `server.tool` for registration.
-      server.tool(
+      // Convert Zod schema to JSON Schema with explicit type fields for Gemini CLI compatibility.
+      // Cast to ZodRawShape as the MCP SDK accepts this at runtime despite TypeScript strictness.
+      const jsonSchema = createJsonSchema(ObsidianDeleteNoteInputSchema) as unknown as z.ZodRawShape;
+      (server.tool as any)(
         toolName,
         toolDescription,
-        ObsidianDeleteNoteInputSchema.shape, // Provide the Zod schema shape for input definition.
+        jsonSchema, // Provide the JSON Schema with explicit type fields.
         /**
          * The handler function executed when the 'obsidian_delete_note' tool is called by the client.
          *
@@ -72,7 +77,7 @@ export const registerObsidianDeleteNoteTool = async (
          * @returns {Promise<CallToolResult>} A promise resolving to the structured result for the MCP client,
          *   containing either the successful response data (serialized JSON) or an error indication.
          */
-        async (params: ObsidianDeleteNoteInput) => {
+        async (params: any) => {
           // Type matches the inferred input schema
           // Create a specific context for this handler invocation.
           const handlerContext: RequestContext =

--- a/src/mcp-server/tools/obsidianGlobalSearchTool/logic.ts
+++ b/src/mcp-server/tools/obsidianGlobalSearchTool/logic.ts
@@ -21,7 +21,7 @@ import {
 // ====================================================================================
 // Schema Definitions (Updated for Pagination, Match Limit, and Path Filter)
 // ====================================================================================
-const ObsidianGlobalSearchInputSchema = z
+export const ObsidianGlobalSearchInputSchema = z
   .object({
     query: z
       .string()

--- a/src/mcp-server/tools/obsidianGlobalSearchTool/registration.ts
+++ b/src/mcp-server/tools/obsidianGlobalSearchTool/registration.ts
@@ -8,11 +8,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
 import type { VaultCacheService } from "../../../services/obsidianRestAPI/vaultCache/index.js"; // Import VaultCacheService type
 import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+import { z } from "zod";
 import {
   ErrorHandler,
   logger,
   RequestContext,
   requestContextService,
+  createJsonSchema,
 } from "../../../utils/index.js";
 // Import types, schema shape, and the core processing logic from logic.ts
 import type {
@@ -20,6 +22,7 @@ import type {
   ObsidianGlobalSearchResponse,
 } from "./logic.js"; // Ensure '.js' extension
 import {
+  ObsidianGlobalSearchInputSchema,
   ObsidianGlobalSearchInputSchemaShape,
   processObsidianGlobalSearch,
 } from "./logic.js"; // Ensure '.js' extension
@@ -52,10 +55,13 @@ export async function registerObsidianGlobalSearchTool(
 
   await ErrorHandler.tryCatch(
     async () => {
-      server.tool(
+      // Convert Zod schema to JSON Schema with explicit type fields for Gemini CLI compatibility.
+      // Cast to ZodRawShape as the MCP SDK accepts this at runtime despite TypeScript strictness.
+      const jsonSchema = createJsonSchema(ObsidianGlobalSearchInputSchema) as unknown as z.ZodRawShape;
+      (server.tool as any)(
         toolName,
         toolDescription,
-        ObsidianGlobalSearchInputSchemaShape,
+        jsonSchema,
         async (
           params: ObsidianGlobalSearchInput,
           handlerInvocationContext: any,

--- a/src/mcp-server/tools/obsidianListNotesTool/registration.ts
+++ b/src/mcp-server/tools/obsidianListNotesTool/registration.ts
@@ -6,6 +6,7 @@
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
 import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
 import {
@@ -13,6 +14,7 @@ import {
   logger,
   RequestContext,
   requestContextService,
+  createJsonSchema,
 } from "../../../utils/index.js";
 // Import necessary types, schema, and logic function from the logic file
 import type {
@@ -60,10 +62,13 @@ export const registerObsidianListNotesTool = async (
   await ErrorHandler.tryCatch(
     async () => {
       // Use the high-level SDK method `server.tool` for registration.
-      server.tool(
+      // Convert Zod schema to JSON Schema with explicit type fields for Gemini CLI compatibility.
+      // Cast to ZodRawShape as the MCP SDK accepts this at runtime despite TypeScript strictness.
+      const jsonSchema = createJsonSchema(ObsidianListNotesInputSchema) as unknown as z.ZodRawShape;
+      (server.tool as any)(
         toolName,
         toolDescription,
-        ObsidianListNotesInputSchema.shape, // Provide the Zod schema shape for input definition.
+        jsonSchema, // Provide the JSON Schema with explicit type fields.
         /**
          * The handler function executed when the 'obsidian_list_notes' tool is called by the client.
          *
@@ -72,7 +77,7 @@ export const registerObsidianListNotesTool = async (
          * @returns {Promise<CallToolResult>} A promise resolving to the structured result for the MCP client,
          *   containing either the successful response data (serialized JSON) or an error indication.
          */
-        async (params: ObsidianListNotesInput) => {
+        async (params: any) => {
           // Type matches the inferred input schema
           // Create a specific context for this handler invocation.
           const handlerContext: RequestContext =

--- a/src/mcp-server/tools/obsidianManageFrontmatterTool/registration.ts
+++ b/src/mcp-server/tools/obsidianManageFrontmatterTool/registration.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import {
   ObsidianRestApiService,
   VaultCacheService,
@@ -9,6 +10,7 @@ import {
   logger,
   RequestContext,
   requestContextService,
+  createJsonSchema,
 } from "../../../utils/index.js";
 import type {
   ObsidianManageFrontmatterInput,
@@ -40,11 +42,14 @@ export const registerObsidianManageFrontmatterTool = async (
 
   await ErrorHandler.tryCatch(
     async () => {
-      server.tool(
+      // Convert Zod schema to JSON Schema with explicit type fields for Gemini CLI compatibility.
+      // Cast to ZodRawShape as the MCP SDK accepts this at runtime despite TypeScript strictness.
+      const jsonSchema = createJsonSchema(ManageFrontmatterInputSchema) as unknown as z.ZodRawShape;
+      (server.tool as any)(
         toolName,
         toolDescription,
-        ObsidianManageFrontmatterInputSchemaShape,
-        async (params: ObsidianManageFrontmatterInput) => {
+        jsonSchema,
+        async (params: any) => {
           const handlerContext: RequestContext =
             requestContextService.createRequestContext({
               parentContext: registrationContext,

--- a/src/mcp-server/tools/obsidianManageTagsTool/registration.ts
+++ b/src/mcp-server/tools/obsidianManageTagsTool/registration.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import {
   ObsidianRestApiService,
   VaultCacheService,
@@ -9,6 +10,7 @@ import {
   logger,
   RequestContext,
   requestContextService,
+  createJsonSchema,
 } from "../../../utils/index.js";
 import type {
   ObsidianManageTagsInput,
@@ -40,11 +42,14 @@ export const registerObsidianManageTagsTool = async (
 
   await ErrorHandler.tryCatch(
     async () => {
-      server.tool(
+      // Convert Zod schema to JSON Schema with explicit type fields for Gemini CLI compatibility.
+      // Cast to ZodRawShape as the MCP SDK accepts this at runtime despite TypeScript strictness.
+      const jsonSchema = createJsonSchema(ManageTagsInputSchema) as unknown as z.ZodRawShape;
+      (server.tool as any)(
         toolName,
         toolDescription,
-        ObsidianManageTagsInputSchemaShape,
-        async (params: ObsidianManageTagsInput) => {
+        jsonSchema,
+        async (params: any) => {
           const handlerContext: RequestContext =
             requestContextService.createRequestContext({
               parentContext: registrationContext,

--- a/src/mcp-server/tools/obsidianReadNoteTool/registration.ts
+++ b/src/mcp-server/tools/obsidianReadNoteTool/registration.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
 import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
 import {
@@ -6,6 +7,7 @@ import {
   logger,
   RequestContext,
   requestContextService,
+  createJsonSchema,
 } from "../../../utils/index.js";
 // Import necessary types, schema, and logic function from the logic file
 import type {
@@ -57,10 +59,15 @@ export const registerObsidianReadNoteTool = async (
     async () => {
       // Use the high-level SDK method `server.tool` for registration.
       // It handles schema generation from the shape, basic validation, and routing.
-      server.tool(
+      // Convert Zod schema to JSON Schema with explicit type fields for Gemini CLI compatibility.
+      // Cast to ZodRawShape as the MCP SDK accepts this at runtime despite TypeScript strictness.
+      const jsonSchema = createJsonSchema(ObsidianReadNoteInputSchema) as unknown as z.ZodRawShape;
+      // Cast server.tool to any to bypass TypeScript strict type checking on overloads
+      // The runtime behavior is correct - the MCP SDK accepts both Zod schemas and JSON Schema objects
+      (server.tool as any)(
         toolName,
         toolDescription,
-        ObsidianReadNoteInputSchema.shape, // Provide the Zod schema shape for input definition.
+        jsonSchema,
         /**
          * The handler function executed when the 'obsidian_read_note' tool is called by the client.
          *
@@ -71,7 +78,7 @@ export const registerObsidianReadNoteTool = async (
          * @returns {Promise<CallToolResult>} A promise resolving to the structured result for the MCP client,
          *   containing either the successful response data (serialized JSON) or an error indication.
          */
-        async (params: ObsidianReadNoteInput) => {
+        async (params: any) => {
           // Type matches the inferred input schema
           // Create a specific context for this handler invocation.
           const handlerContext: RequestContext =

--- a/src/mcp-server/tools/obsidianSearchReplaceTool/registration.ts
+++ b/src/mcp-server/tools/obsidianSearchReplaceTool/registration.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import {
   ObsidianRestApiService,
   VaultCacheService,
@@ -9,6 +10,7 @@ import {
   logger,
   RequestContext,
   requestContextService,
+  createJsonSchema,
 } from "../../../utils/index.js";
 // Import necessary types and schemas from the logic file
 import type {
@@ -64,10 +66,13 @@ export const registerObsidianSearchReplaceTool = async (
     async () => {
       // Use the high-level SDK method `server.tool` for registration.
       // It handles schema generation from the shape, basic validation, and routing.
-      server.tool(
+      // Convert Zod schema to JSON Schema with explicit type fields for Gemini CLI compatibility.
+      // Cast to ZodRawShape as the MCP SDK accepts this at runtime despite TypeScript strictness.
+      const jsonSchema = createJsonSchema(ObsidianSearchReplaceInputSchema) as unknown as z.ZodRawShape;
+      (server.tool as any)(
         toolName,
         toolDescription,
-        ObsidianSearchReplaceInputSchemaShape, // Provide the base Zod schema shape for input definition.
+        jsonSchema,
         /**
          * The handler function executed when the 'obsidian_search_replace' tool is called by the client.
          *
@@ -76,7 +81,7 @@ export const registerObsidianSearchReplaceTool = async (
          * @returns {Promise<CallToolResult>} A promise resolving to the structured result for the MCP client,
          *   containing either the successful response data (serialized JSON) or an error indication.
          */
-        async (params: ObsidianSearchReplaceRegistrationInput) => {
+        async (params: any) => {
           // Create a specific context for this handler invocation, linked to the registration context.
           const handlerContext: RequestContext =
             requestContextService.createRequestContext({

--- a/src/mcp-server/tools/obsidianUpdateNoteTool/registration.ts
+++ b/src/mcp-server/tools/obsidianUpdateNoteTool/registration.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import {
   ObsidianRestApiService,
   VaultCacheService,
@@ -9,6 +10,7 @@ import {
   logger,
   RequestContext,
   requestContextService,
+  createJsonSchema,
 } from "../../../utils/index.js";
 // Import types for handler signature and response structure
 import type {
@@ -64,10 +66,13 @@ export const registerObsidianUpdateNoteTool = async (
     async () => {
       // Use the high-level SDK method for tool registration.
       // This handles schema generation, validation, and routing automatically.
-      server.tool(
+      // Convert Zod schema to JSON Schema with explicit type fields for Gemini CLI compatibility.
+      // Cast to ZodRawShape as the MCP SDK accepts this at runtime despite TypeScript strictness.
+      const jsonSchema = createJsonSchema(ObsidianUpdateNoteInputSchema) as unknown as z.ZodRawShape;
+      (server.tool as any)(
         toolName,
         toolDescription,
-        ObsidianUpdateNoteInputSchemaShape, // Provide the Zod schema shape for input validation.
+        jsonSchema, // Provide the JSON Schema with explicit type fields.
         /**
          * The handler function executed when the 'obsidian_update_note' tool is called.
          *
@@ -76,7 +81,7 @@ export const registerObsidianUpdateNoteTool = async (
          * @returns {Promise<CallToolResult>} A promise resolving to the structured result for the MCP client,
          *   containing either the successful response data or an error indication.
          */
-        async (params: ObsidianUpdateNoteRegistrationInput) => {
+        async (params: any) => {
           // Create a specific context for this handler invocation.
           const handlerContext: RequestContext =
             requestContextService.createRequestContext({

--- a/src/utils/parsing/index.ts
+++ b/src/utils/parsing/index.ts
@@ -1,3 +1,4 @@
 export * from "./jsonParser.js";
 export * from "./dateParser.js";
+export * from "./zodSchemaToJson.js";
 // Removed export for dateUtils.js as it was moved

--- a/src/utils/parsing/zodSchemaToJson.ts
+++ b/src/utils/parsing/zodSchemaToJson.ts
@@ -1,0 +1,224 @@
+import { z } from "zod";
+
+/**
+ * Converts a Zod typeName to the corresponding JSON Schema type string.
+ * @param typeName - The Zod typeName (e.g., "ZodString", "ZodNumber", "ZodBoolean")
+ * @returns The JSON Schema type string (e.g., "string", "number", "boolean")
+ */
+function zodTypeNameToJsonType(typeName: string): string {
+  const typeMap: Record<string, string> = {
+    ZodString: "string",
+    ZodNumber: "number",
+    ZodBoolean: "boolean",
+    ZodArray: "array",
+    ZodObject: "object",
+    ZodEnum: "string",
+    ZodOptional: "string", // Will be handled specially
+    ZodDefault: "string", // Will be handled specially
+    ZodLiteral: "string",
+    ZodUnion: "string", // Simplified - unions become string for enum-like usage
+    ZodIntersection: "object",
+    ZodRecord: "object",
+    ZodMap: "object",
+    ZodSet: "array",
+    ZodFunction: "object",
+    ZodLazy: "object",
+    ZodNativeEnum: "string",
+    ZodEffects: "string", // Transform effects inherit from inner type
+    ZodTuple: "array",
+    ZodUndefined: "undefined",
+    ZodNull: "null",
+    ZodAny: "object",
+    ZodUnknown: "object",
+    ZodNever: "null",
+    ZodVoid: "null",
+  };
+
+  const result = typeMap[typeName] || "object";
+  return result;
+}
+
+/**
+ * Extracts the JSON Schema type from a Zod field definition, handling wrapped types
+ * like ZodOptional, ZodDefault, etc.
+ */
+function extractJsonType(def: any): { type: string; innerDef?: any } {
+  const typeName = def.typeName;
+
+  // Handle wrapped types
+  if (typeName === "ZodOptional" || typeName === "ZodDefault") {
+    const innerType = def.innerType?._def || def._def?.innerType;
+    if (innerType) {
+      const inner = extractJsonType(innerType);
+      return { type: inner.type, innerDef: inner };
+    }
+  }
+
+  // Handle ZodEffects (e.g., ZodString with transformations)
+  if (typeName === "ZodEffects") {
+    const innerType = def.innerType?._def;
+    if (innerType) {
+      return extractJsonType(innerType);
+    }
+  }
+
+  // Handle arrays
+  if (typeName === "ZodArray") {
+    return { type: "array", innerDef: def };
+  }
+
+  // Handle enum - extract values
+  if (typeName === "ZodEnum") {
+    return { type: "string", innerDef: def };
+  }
+
+  // Handle literal
+  if (typeName === "ZodLiteral") {
+    return { type: typeof def.value };
+  }
+
+  // Handle base types
+  return { type: zodTypeNameToJsonType(typeName), innerDef: def };
+}
+
+/**
+ * Extracts description from a Zod field definition.
+ */
+function extractDescription(def: any): string | undefined {
+  // Check description in various places Zod stores it
+  if (def.description) {
+    return def.description;
+  }
+  // For wrapped types, check inner
+  if (def.innerType?._def?.description) {
+    return def.innerType._def.description;
+  }
+  if (def._def?.innerType?._def?.description) {
+    return def._def.innerType._def.description;
+  }
+  return undefined;
+}
+
+/**
+ * Extracts default value from a Zod field definition.
+ */
+function extractDefault(def: any): any {
+  if (def.typeName === "ZodDefault") {
+    return def.defaultValue();
+  }
+  if (def.innerType?._def?.typeName === "ZodDefault") {
+    return def.innerType._def.defaultValue();
+  }
+  return undefined;
+}
+
+/**
+ * Extracts enum values from a Zod schema definition.
+ */
+function extractEnumValues(def: any): string[] | undefined {
+  if (def.typeName === "ZodEnum") {
+    return def.values;
+  }
+  if (def.innerType?._def?.typeName === "ZodEnum") {
+    return def.innerType._def.values;
+  }
+  if (def._def?.innerType?._def?.typeName === "ZodEnum") {
+    return def._def.innerType._def.values;
+  }
+  return undefined;
+}
+
+/**
+ * Converts a Zod schema shape object to a proper JSON Schema object with explicit type fields.
+ *
+ * @param shape - The Zod schema shape object (from `schema.shape`)
+ * @returns A JSON Schema object with explicit `type` fields for each property
+ */
+export function convertZodShapeToJsonSchema(
+  shape: Record<string, any>,
+): Record<string, any> {
+  const properties: Record<string, any> = {};
+  const required: string[] = [];
+
+  for (const [key, fieldDef] of Object.entries(shape)) {
+    const def = fieldDef._def || fieldDef;
+    const { type, innerDef } = extractJsonType(def);
+    const description = extractDescription(def);
+    const enumValues = extractEnumValues(def);
+    const defaultValue = extractDefault(def);
+
+    const propertySchema: Record<string, any> = {
+      type,
+    };
+
+    if (description) {
+      propertySchema.description = description;
+    }
+
+    if (enumValues) {
+      propertySchema.enum = enumValues;
+      // Remove type when enum is present as it's more specific
+      delete propertySchema.type;
+    }
+
+    if (defaultValue !== undefined) {
+      propertySchema.default = defaultValue;
+    }
+
+    // Handle array items
+    if (type === "array" && def.typeName === "ZodArray") {
+      const itemsDef = def.innerType?._def || def._def?.innerType;
+      if (itemsDef) {
+        const itemsType = extractJsonType(itemsDef);
+        propertySchema.items = { type: itemsType.type };
+        if (itemsType.innerDef?.typeName === "ZodEnum") {
+          propertySchema.items.enum = itemsType.innerDef.values;
+          delete propertySchema.items.type;
+        }
+      }
+    }
+
+    properties[key] = propertySchema;
+
+    // Field is required if it doesn't have ZodOptional wrapper
+    const isOptional =
+      def.typeName === "ZodOptional" ||
+      fieldDef.isOptional?.() ||
+      false;
+    if (!isOptional) {
+      required.push(key);
+    }
+  }
+
+  const result: Record<string, any> = {
+    type: "object",
+    properties,
+  };
+
+  if (required.length > 0) {
+    result.required = required;
+  }
+
+  return result;
+}
+
+/**
+ * Creates a JSON Schema from a Zod schema that can be used with MCP SDK.
+ * This ensures all fields have explicit "type" declarations.
+ *
+ * @param schema - A Zod schema (or schema shape)
+ * @returns A JSON Schema object with explicit type fields
+ */
+export function createJsonSchema(
+  schema: z.ZodTypeAny | Record<string, any>,
+): Record<string, any> {
+  // If it's already a Zod schema, get its shape
+  const shape =
+    'shape' in schema
+      ? (schema as z.ZodObject<any>).shape
+      : 'shape' in (schema as any)?._def
+        ? (schema as any)._def.shape
+        : (schema as Record<string, any>);
+
+  return convertZodShapeToJsonSchema(shape);
+}


### PR DESCRIPTION
## Summary

Gemini CLI v1.9.0+ uses stricter validation requiring explicit "type" fields in parameter schemas. This PR adds a `createJsonSchema` utility that converts Zod schemas to proper JSON Schema format with explicit type declarations.

## Changes

- **New utility**: `src/utils/parsing/zodSchemaToJson.ts` - Converts Zod schemas to JSON Schema with explicit `type` fields
- **Updated all 8 tool registrations** to use `createJsonSchema()` for schema conversion
- **Fixed `obsidianGlobalSearchInputSchema`** to be exported for use in registration

## Root Cause

The MCP SDK's `server.tool()` method was receiving Zod schema shapes (`schema.shape`), which contain internal `_def` objects with `typeName` fields like `"ZodString"`, but not standard JSON Schema `type` fields like `"string"`. Gemini CLI v1.9.0+ validates against `parametersJsonSchema` which requires explicit `type` declarations.

## Fix

Added `createJsonSchema()` utility that:
1. Extracts the Zod schema shape
2. Converts each field's `typeName` (e.g., `ZodString`) to JSON Schema `type` (e.g., `"string"`)
3. Preserves `description`, `enum` values, and `default` values
4. Handles wrapped types like `ZodOptional`, `ZodDefault`, and `ZodArray`

## Test Plan

- [x] Build passes (`npm run build`)
- [x] Code compiles without TypeScript errors
- [x] Manual verification of JSON schema output shows explicit `type` fields

Fixes #19