### PR TITLE
feat: add OBSIDIAN_READ_ONLY env var to disable write tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,7 @@ OBSIDIAN_API_KEY=
 # obsidian_execute_command). Off by default — Obsidian commands are opaque
 # and can be destructive (delete file, close vault, etc.).
 # OBSIDIAN_ENABLE_COMMANDS=false
+
+# Read-only mode — when true, only read-only tools (get, list, search) are
+# registered. All write tools and the command-palette pair are excluded.
+# OBSIDIAN_READ_ONLY=false

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Obsidian-specific:
 - Tag reconciliation across both representations: frontmatter `tags:` array and inline `#tag` syntax (skipping fenced code blocks)
 - Search across three modes: text, Dataview DQL, JSONLogic — with overflow indicator when results exceed the 100-hit cap
 - Optional human-in-the-loop confirmation for destructive deletes via `ctx.elicit`
+- Read-only mode (`OBSIDIAN_READ_ONLY=true`) — disables all write tools, leaving only read/search operations registered
 - Opt-in command-palette pair (`obsidian_list_commands` + `obsidian_execute_command`) — registered only when `OBSIDIAN_ENABLE_COMMANDS=true`
 - Forgiving path resolution on `obsidian_get_note` and `obsidian_open_in_ui` — silently retries case-mismatched paths against the canonical filename, throws `Conflict` on ambiguous case matches, and enriches `NotFound` with `Did you mean: …?` suggestions when only near-matches exist. `obsidian_delete_note` is deliberately excluded — a destructive op shouldn't silently rewrite the target path.
 
@@ -247,6 +248,7 @@ MCP_TRANSPORT_TYPE=http OBSIDIAN_API_KEY=... bun run start:http
 | `OBSIDIAN_VERIFY_SSL` | Verify the TLS certificate. Default `false` because the plugin uses a self-signed cert. On Node, the dispatcher's `rejectUnauthorized` option handles this without any process-wide change. On Bun, the runtime ignores that option, so the service additionally sets `NODE_TLS_REJECT_UNAUTHORIZED=0` — that fallback is scoped to Bun only. | `false` |
 | `OBSIDIAN_REQUEST_TIMEOUT_MS` | Per-request timeout in milliseconds. | `30000` |
 | `OBSIDIAN_ENABLE_COMMANDS` | Opt-in flag for the command-palette pair (`obsidian_list_commands` + `obsidian_execute_command`). Off by default — Obsidian commands are opaque and can be destructive. | `false` |
+| `OBSIDIAN_READ_ONLY` | When `true`, only read-only tools are registered — all tools that create, modify, or delete notes are disabled. Also suppresses the command-palette pair regardless of `OBSIDIAN_ENABLE_COMMANDS`. | `false` |
 | `MCP_TRANSPORT_TYPE` | Transport: `stdio` or `http`. | `stdio` |
 | `MCP_HTTP_HOST` | Host for the HTTP server. | `127.0.0.1` |
 | `MCP_HTTP_PORT` | Port for the HTTP server. | `3010` |

--- a/src/config/server-config.ts
+++ b/src/config/server-config.ts
@@ -46,6 +46,11 @@ const ServerConfigSchema = z.object({
     .describe(
       'Opt-in flag for the command-palette pair (`obsidian_list_commands` + `obsidian_execute_command`). Off by default — Obsidian commands are opaque and can be destructive.',
     ),
+  readOnly: envBoolean
+    .default(false)
+    .describe(
+      'When true, only read-only tools are registered — all tools that create, modify, or delete notes are disabled. Useful for shared or public-facing deployments where vault mutation must be prevented.',
+    ),
 });
 
 export type ServerConfig = z.infer<typeof ServerConfigSchema>;
@@ -59,6 +64,7 @@ export function getServerConfig(): ServerConfig {
     verifySsl: 'OBSIDIAN_VERIFY_SSL',
     requestTimeoutMs: 'OBSIDIAN_REQUEST_TIMEOUT_MS',
     enableCommands: 'OBSIDIAN_ENABLE_COMMANDS',
+    readOnly: 'OBSIDIAN_READ_ONLY',
   });
   return _config;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,15 +11,18 @@ import { getServerConfig } from '@/config/server-config.js';
 import { allPromptDefinitions } from '@/mcp-server/prompts/definitions/index.js';
 import { allResourceDefinitions } from '@/mcp-server/resources/definitions/index.js';
 import {
-  baseToolDefinitions,
   commandToolDefinitions,
+  readOnlyToolDefinitions,
+  writeToolDefinitions,
 } from '@/mcp-server/tools/definitions/index.js';
 import { initObsidianService } from '@/services/obsidian/obsidian-service.js';
 
 const config = getServerConfig();
-const tools = config.enableCommands
-  ? [...baseToolDefinitions, ...commandToolDefinitions]
-  : baseToolDefinitions;
+const tools = [
+  ...readOnlyToolDefinitions,
+  ...(config.readOnly ? [] : writeToolDefinitions),
+  ...(config.enableCommands && !config.readOnly ? commandToolDefinitions : []),
+];
 
 await createApp({
   tools,

--- a/src/mcp-server/tools/definitions/index.ts
+++ b/src/mcp-server/tools/definitions/index.ts
@@ -22,12 +22,16 @@ import { obsidianReplaceInNote } from './obsidian-replace-in-note.tool.js';
 import { obsidianSearchNotes } from './obsidian-search-notes.tool.js';
 import { obsidianWriteNote } from './obsidian-write-note.tool.js';
 
-/** Tools registered unconditionally on every server. */
-export const baseToolDefinitions = [
+/** Read-only tools — always registered, even in read-only mode. */
+export const readOnlyToolDefinitions = [
   obsidianGetNote,
   obsidianListNotes,
   obsidianListTags,
   obsidianSearchNotes,
+];
+
+/** Write tools — tools that create, modify, or delete notes. Excluded when `OBSIDIAN_READ_ONLY=true`. */
+export const writeToolDefinitions = [
   obsidianWriteNote,
   obsidianAppendToNote,
   obsidianPatchNote,
@@ -37,6 +41,9 @@ export const baseToolDefinitions = [
   obsidianDeleteNote,
   obsidianOpenInUi,
 ];
+
+/** Tools registered unconditionally on every server (read-only mode respects the split). */
+export const baseToolDefinitions = [...readOnlyToolDefinitions, ...writeToolDefinitions];
 
 /** Command-palette tools — registered only when `OBSIDIAN_ENABLE_COMMANDS=true`. */
 export const commandToolDefinitions = [obsidianListCommands, obsidianExecuteCommand];


### PR DESCRIPTION
## Summary
- Adds `OBSIDIAN_READ_ONLY` environment variable (default `false`) that, when `true`, registers only read-only tools (`get_note`, `list_notes`, `list_tags`, `search_notes`)
- All write tools (`write_note`, `append_to_note`, `patch_note`, `replace_in_note`, `manage_frontmatter`, `manage_tags`, `delete_note`, `open_in_ui`) and the command-palette pair are excluded in read-only mode
- Documented in README env var table, features list, and `.env.example`

## Test plan
- [ ] Set `OBSIDIAN_READ_ONLY=true` and verify only 4 read-only tools are registered
- [ ] Set `OBSIDIAN_READ_ONLY=false` (or omit) and verify all tools are registered as before
- [ ] Set both `OBSIDIAN_READ_ONLY=true` and `OBSIDIAN_ENABLE_COMMANDS=true` — verify command-palette tools are still excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)