### PR TITLE
feat: add obsidian_omnisearch tool (opt-in)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,19 @@ OBSIDIAN_API_KEY=
 # and can be destructive (delete file, close vault, etc.).
 # OBSIDIAN_ENABLE_COMMANDS=false
 
+# ── Omnisearch bridge (community plugin) ─────────────────────────────
+# Opt-in flag for `obsidian_omnisearch`. Requires the Omnisearch community
+# plugin with its HTTP server enabled (Obsidian → Settings → Omnisearch →
+# Enable HTTP server). When false (default) the tool stays in the manifest
+# as `disabled` so operators see why it's unavailable.
+# OBSIDIAN_OMNISEARCH_ENABLE=false
+#
+# Base URL of the Omnisearch plugin HTTP server. Defaults to
+# `http://localhost:51361` because on macOS the plugin binds IPv6-only
+# (`[::1]:51361`) — `localhost` lets undici happy-eyeballs reach either
+# stack. On IPv4-only platforms override with `http://127.0.0.1:51361`.
+# OBSIDIAN_OMNISEARCH_BASE_URL=http://localhost:51361
+
 # ── Path policy (folder-scoped read/write) ───────────────────────────
 # Optional vault-relative folder allowlists. Comma-separated; prefix-based
 # with implicit recursion; case-insensitive; trailing slashes normalized.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <h1>obsidian-mcp-server</h1>
   <p><b>MCP server for Obsidian vaults — read, write, search, and surgically edit notes, tags, and frontmatter via the Local REST API plugin. STDIO or Streamable HTTP.</b>
-  <div>14 Tools • 3 Resources</div>
+  <div>15 Tools • 3 Resources</div>
   </p>
 </div>
 
@@ -17,7 +17,7 @@
 
 ## Tools
 
-Fourteen tools grouped by shape — readers fetch notes and metadata, writers create or surgically edit content, managers reconcile tags and frontmatter, and a guarded escape hatch dispatches Obsidian command-palette commands.
+Fifteen tools grouped by shape — readers fetch notes and metadata, writers create or surgically edit content, managers reconcile tags and frontmatter, a guarded escape hatch dispatches Obsidian command-palette commands, and an opt-in indexed search bridges to the Omnisearch community plugin.
 
 | Tool Name | Description |
 |:----------|:------------|
@@ -26,6 +26,7 @@ Fourteen tools grouped by shape — readers fetch notes and metadata, writers cr
 | `obsidian_list_tags` | List every tag found across the vault with usage counts, including hierarchical parents. |
 | `obsidian_list_commands` | List Obsidian command-palette commands available for execution. **Opt-in via `OBSIDIAN_ENABLE_COMMANDS=true`** (paired with `obsidian_execute_command`). |
 | `obsidian_search_notes` | Search the vault by text, Dataview DQL, or JSONLogic — capped at 100 hits with overflow indicator. |
+| `obsidian_omnisearch` | Indexed fuzzy full-text search via the Omnisearch community plugin's HTTP server. Returns Omnisearch relevance scores, matched-word lists, and excerpts. **Opt-in via `OBSIDIAN_OMNISEARCH_ENABLE=true`.** |
 | `obsidian_write_note` | Create a note, replace a single section in place, or — with `overwrite: true` — clobber an existing file. Refuses whole-file writes against an existing path by default. |
 | `obsidian_append_to_note` | Append content to a note, or to a specific heading/block/frontmatter section. |
 | `obsidian_patch_note` | Surgical `append` / `prepend` / `replace` against a heading, block reference, or frontmatter field. |
@@ -58,6 +59,20 @@ Three search modes selected by `mode`:
 - `jsonlogic` — JSONLogic tree evaluated against `path`, `content`, `frontmatter.<key>`, `tags`, and `stat.{ctime,mtime,size}`; custom `glob` and `regexp` operators
 
 Results are capped at 100 hits. When the upstream returns more, an `excluded` indicator surfaces the overflow count and a hint to narrow the query. Text-mode hits are additionally clipped per file at `maxMatchesPerHit` (default 10) so a single match-heavy note can't blow the response budget — clipped hits carry `truncated: true` and `totalMatches`.
+
+---
+
+### `obsidian_omnisearch`
+
+Indexed fuzzy full-text search backed by the [Omnisearch community plugin](https://github.com/scambier/obsidian-omnisearch). Much faster than `obsidian_search_notes` on large vaults, and returns Omnisearch's relevance scoring, matched-word lists, and excerpts.
+
+**Off by default.** Set `OBSIDIAN_OMNISEARCH_ENABLE=true` after installing the Omnisearch plugin and enabling its HTTP server (Obsidian → Settings → Omnisearch → *Enable HTTP server*). The tool stays in the manifest as `disabled` when the flag is off so operators see why it's unavailable.
+
+`OBSIDIAN_OMNISEARCH_BASE_URL` defaults to `http://localhost:51361` — on macOS the plugin binds IPv6-only (`[::1]:51361`), so `localhost` is used to let undici happy-eyeballs reach either stack. On IPv4-only platforms set `http://127.0.0.1:51361` explicitly.
+
+Results are capped at 100 hits with the same `excluded` overflow indicator as `obsidian_search_notes`. Per-file matches clip at `maxMatchesPerFile` (default 5, 0 drops the match arrays entirely and keeps only score + excerpt). Optional `pathPrefix` filter is applied client-side. Hits are post-filtered against `OBSIDIAN_READ_PATHS` so path-policy applies uniformly with the other read tools.
+
+Upstream failures (plugin offline, HTTP 5xx, transport refused) surface as `omnisearch_unreachable` (`ServiceUnavailable`) with a recovery hint pointing operators back to the plugin setup.
 
 ---
 
@@ -143,7 +158,7 @@ Three optional env vars gate which vault paths each tool can target. **Default u
 
 **`OBSIDIAN_READ_ONLY=true` short-circuits before the path checks** — every write is denied regardless of `WRITE_PATHS`, and the command-palette pair is unregistered regardless of `OBSIDIAN_ENABLE_COMMANDS` (commands can mutate).
 
-Denies are typed `path_forbidden` (JSON-RPC code `Forbidden`) with the active scope echoed back in `data.recovery.hint` and `data.activeScope`, so the LLM can self-correct without inspecting server logs. Search results from `obsidian_search_notes` are filtered against `READ_PATHS` silently — surfacing a "we hid N hits" indicator would defeat the gate.
+Denies are typed `path_forbidden` (JSON-RPC code `Forbidden`) with the active scope echoed back in `data.recovery.hint` and `data.activeScope`, so the LLM can self-correct without inspecting server logs. Search results from `obsidian_search_notes` and `obsidian_omnisearch` are filtered against `READ_PATHS` silently — surfacing a "we hid N hits" indicator would defeat the gate.
 
 The startup banner logs the active scope so operators can verify their config at boot.
 
@@ -271,6 +286,8 @@ MCP_TRANSPORT_TYPE=http OBSIDIAN_API_KEY=... bun run start:http
 | `OBSIDIAN_VERIFY_SSL` | Verify the TLS certificate. Default `false` because the plugin uses a self-signed cert. On Node, the dispatcher's `rejectUnauthorized` option handles this without any process-wide change. On Bun, the runtime ignores that option, so the service additionally sets `NODE_TLS_REJECT_UNAUTHORIZED=0` — that fallback is scoped to Bun only. | `false` |
 | `OBSIDIAN_REQUEST_TIMEOUT_MS` | Per-request timeout in milliseconds. | `30000` |
 | `OBSIDIAN_ENABLE_COMMANDS` | Opt-in flag for the command-palette pair (`obsidian_list_commands` + `obsidian_execute_command`). Off by default — Obsidian commands are opaque and can be destructive. | `false` |
+| `OBSIDIAN_OMNISEARCH_ENABLE` | Opt-in flag for `obsidian_omnisearch`. Requires the Omnisearch community plugin with its HTTP server enabled. | `false` |
+| `OBSIDIAN_OMNISEARCH_BASE_URL` | Base URL of the Omnisearch plugin HTTP server. Default uses `localhost` so undici happy-eyeballs reaches either IP stack (the plugin binds IPv6-only on macOS). Override with `http://127.0.0.1:51361` on IPv4-only platforms. | `http://localhost:51361` |
 | `OBSIDIAN_READ_PATHS` | Comma-separated vault-relative folder allowlist for read operations. Prefix-based with implicit recursion; case-insensitive; trailing slashes normalized. Unset = full vault. Write paths are implicitly readable. | unset |
 | `OBSIDIAN_WRITE_PATHS` | Comma-separated vault-relative folder allowlist for write operations. Same syntax as `OBSIDIAN_READ_PATHS`. Unset = full vault. | unset |
 | `OBSIDIAN_READ_ONLY` | Global kill switch. When `true`, denies every write regardless of `OBSIDIAN_WRITE_PATHS`, and suppresses the `OBSIDIAN_ENABLE_COMMANDS` pair (commands can mutate). | `false` |

--- a/scripts/smoke-omnisearch.ts
+++ b/scripts/smoke-omnisearch.ts
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview Smoke test for obsidian_omnisearch — runs the tool handler
+ * end-to-end against a live Obsidian + Omnisearch + Local REST API.
+ * Run with:
+ *   OBSIDIAN_API_KEY=... \
+ *   OBSIDIAN_BASE_URL=https://127.0.0.1:27124 \
+ *   OBSIDIAN_VERIFY_SSL=false \
+ *   OBSIDIAN_OMNISEARCH_ENABLE=true \
+ *   OBSIDIAN_OMNISEARCH_BASE_URL=http://[::1]:51361 \
+ *   bun run scripts/smoke-omnisearch.ts <query>
+ * @module scripts/smoke-omnisearch
+ */
+
+import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
+import { getServerConfig } from '@/config/server-config.js';
+import { obsidianOmnisearch } from '@/mcp-server/tools/definitions/obsidian-omnisearch.tool.js';
+import { initObsidianService } from '@/services/obsidian/obsidian-service.js';
+import { initOmnisearchService } from '@/services/omnisearch/omnisearch-service.js';
+
+const query = process.argv[2] ?? 'context';
+
+const config = getServerConfig();
+if (!config.enableOmnisearch) {
+  console.error('OBSIDIAN_OMNISEARCH_ENABLE must be true for this smoke test.');
+  process.exit(2);
+}
+
+initObsidianService(config);
+initOmnisearchService(config);
+
+const ctx = createMockContext();
+
+const result = await obsidianOmnisearch.handler({ query, limit: 5, maxMatchesPerFile: 3 }, ctx);
+
+console.log('— structuredContent —');
+console.log(JSON.stringify(result, null, 2));
+console.log();
+console.log('— format() content —');
+for (const block of obsidianOmnisearch.format!(result)) {
+  if (block.type === 'text') console.log(block.text);
+}

--- a/scripts/smoke-omnisearch.ts
+++ b/scripts/smoke-omnisearch.ts
@@ -1,41 +1,180 @@
 /**
- * @fileoverview Smoke test for obsidian_omnisearch — runs the tool handler
- * end-to-end against a live Obsidian + Omnisearch + Local REST API.
- * Run with:
- *   OBSIDIAN_API_KEY=... \
- *   OBSIDIAN_BASE_URL=https://127.0.0.1:27124 \
- *   OBSIDIAN_VERIFY_SSL=false \
- *   OBSIDIAN_OMNISEARCH_ENABLE=true \
- *   OBSIDIAN_OMNISEARCH_BASE_URL=http://[::1]:51361 \
- *   bun run scripts/smoke-omnisearch.ts <query>
+ * @fileoverview Smoke runner for obsidian_omnisearch — exercises the tool
+ * handler end-to-end against a live Obsidian + Omnisearch + Local REST API,
+ * plus targeted scenarios for path-policy filtering, the disabled-tool gate,
+ * and the upstream-unreachable error contract.
+ *
+ * Usage:
+ *   bun run scripts/smoke-omnisearch.ts <scenario> [query]
+ *
+ * Scenarios:
+ *   live        — happy-path query against the live plugin (default)
+ *   readpath    — verify OBSIDIAN_READ_PATHS drops out-of-scope hits
+ *   disabled    — verify the disabled-tool gate metadata when ENABLE=false
+ *   unreachable — verify the omnisearch_unreachable error contract
+ *
+ * Required env for `live` / `readpath` / `unreachable`:
+ *   OBSIDIAN_API_KEY, OBSIDIAN_BASE_URL (https://127.0.0.1:27124),
+ *   OBSIDIAN_VERIFY_SSL=false,
+ *   OBSIDIAN_OMNISEARCH_ENABLE=true,
+ *   OBSIDIAN_OMNISEARCH_BASE_URL (http://localhost:51361 by default).
+ *
+ * The `disabled` scenario inspects the entry-point gating logic without
+ * needing a live plugin.
+ *
  * @module scripts/smoke-omnisearch
  */
 
+import { disabledTool } from '@cyanheads/mcp-ts-core';
 import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
-import { getServerConfig } from '@/config/server-config.js';
+import { getServerConfig, resetServerConfig } from '@/config/server-config.js';
 import { obsidianOmnisearch } from '@/mcp-server/tools/definitions/obsidian-omnisearch.tool.js';
 import { initObsidianService } from '@/services/obsidian/obsidian-service.js';
 import { initOmnisearchService } from '@/services/omnisearch/omnisearch-service.js';
 
-const query = process.argv[2] ?? 'context';
+const scenario = process.argv[2] ?? 'live';
+const query = process.argv[3] ?? 'test';
 
-const config = getServerConfig();
-if (!config.enableOmnisearch) {
-  console.error('OBSIDIAN_OMNISEARCH_ENABLE must be true for this smoke test.');
-  process.exit(2);
+async function runLive(): Promise<void> {
+  const config = getServerConfig();
+  if (!config.enableOmnisearch) {
+    console.error('OBSIDIAN_OMNISEARCH_ENABLE must be true for this scenario.');
+    process.exit(2);
+  }
+  initObsidianService(config);
+  initOmnisearchService(config);
+
+  const ctx = createMockContext();
+  const result = await obsidianOmnisearch.handler({ query, limit: 5, maxMatchesPerFile: 3 }, ctx);
+  console.log('— structuredContent —');
+  console.log(JSON.stringify(result, null, 2));
+  console.log();
+  console.log('— format() content —');
+  for (const block of obsidianOmnisearch.format!(result)) {
+    if (block.type === 'text') console.log(block.text);
+  }
 }
 
-initObsidianService(config);
-initOmnisearchService(config);
+async function runReadPath(): Promise<void> {
+  // First run: no scope — captures the path of the top hit so we can
+  // build a deliberately disjoint scope for the second run.
+  const baseline = getServerConfig();
+  if (!baseline.enableOmnisearch) {
+    console.error('OBSIDIAN_OMNISEARCH_ENABLE must be true for this scenario.');
+    process.exit(2);
+  }
+  initObsidianService(baseline);
+  initOmnisearchService(baseline);
+  const ctx = createMockContext();
+  const open = await obsidianOmnisearch.handler({ query, limit: 10, maxMatchesPerFile: 0 }, ctx);
+  console.log(`unscoped: ${open.hits.length} hit(s), totalUpstream ${open.totalUpstream}`);
+  for (const h of open.hits) console.log(`  - ${h.path}`);
+  if (open.hits.length === 0) {
+    console.error('Need at least one hit to exercise the scope filter — try a broader query.');
+    process.exit(2);
+  }
 
-const ctx = createMockContext();
+  const sampleDir = (
+    open.hits[0].path.split('/').slice(0, -1).join('/') || open.hits[0].path
+  ).toLowerCase();
+  const denyScope = '__nonexistent_scope__';
+  console.log();
+  console.log(`scoped to '${denyScope}' (deliberately disjoint):`);
+  resetServerConfig();
+  process.env.OBSIDIAN_READ_PATHS = denyScope;
+  const denyConfig = getServerConfig();
+  initObsidianService(denyConfig);
+  initOmnisearchService(denyConfig);
+  const denied = await obsidianOmnisearch.handler({ query, limit: 10, maxMatchesPerFile: 0 }, ctx);
+  console.log(`  ${denied.hits.length} hit(s), totalUpstream ${denied.totalUpstream}`);
+  if (denied.hits.length !== 0) {
+    console.error('EXPECTED 0 hits after disjoint OBSIDIAN_READ_PATHS — FAIL');
+    process.exit(1);
+  }
+  if (denied.totalUpstream !== open.totalUpstream) {
+    console.error('totalUpstream should match the unscoped run — FAIL');
+    process.exit(1);
+  }
+  console.log('  ✓ path-policy filtered all hits as expected (upstream count preserved)');
 
-const result = await obsidianOmnisearch.handler({ query, limit: 5, maxMatchesPerFile: 3 }, ctx);
+  // Sanity third run: scope to the actual sample dir, expect the hit back.
+  console.log();
+  console.log(`scoped to '${sampleDir}' (covers the sample):`);
+  resetServerConfig();
+  process.env.OBSIDIAN_READ_PATHS = sampleDir || open.hits[0].path.toLowerCase();
+  const allowConfig = getServerConfig();
+  initObsidianService(allowConfig);
+  initOmnisearchService(allowConfig);
+  const allowed = await obsidianOmnisearch.handler({ query, limit: 10, maxMatchesPerFile: 0 }, ctx);
+  console.log(`  ${allowed.hits.length} hit(s)`);
+  if (allowed.hits.length === 0) {
+    console.error('EXPECTED ≥1 hit after permissive scope — FAIL');
+    process.exit(1);
+  }
+  console.log('  ✓ in-scope hits survive the filter');
+}
 
-console.log('— structuredContent —');
-console.log(JSON.stringify(result, null, 2));
-console.log();
-console.log('— format() content —');
-for (const block of obsidianOmnisearch.format!(result)) {
-  if (block.type === 'text') console.log(block.text);
+async function runDisabled(): Promise<void> {
+  // Replicate the wrapping logic from src/index.ts when ENABLE=false. The
+  // metadata is stored on the internal `__mcpDisabled` field — the public
+  // `getDisabledMetadata()` helper isn't re-exported, but the on-object
+  // marker is stable framework contract.
+  const wrapped = disabledTool(obsidianOmnisearch, {
+    reason: 'Disabled by default — requires the Omnisearch community plugin HTTP server.',
+    hint: 'Set OBSIDIAN_OMNISEARCH_ENABLE=true after installing the Omnisearch plugin and enabling its HTTP server (Settings → Omnisearch → "HTTP server").',
+  });
+  const meta = (wrapped as Record<string, unknown>).__mcpDisabled as
+    | { reason: string; hint?: string }
+    | undefined;
+  if (!meta) {
+    console.error('disabledTool() did not attach __mcpDisabled metadata — FAIL');
+    process.exit(1);
+  }
+  console.log('disabled metadata:');
+  console.log(`  reason: ${meta.reason}`);
+  console.log(`  hint:   ${meta.hint}`);
+  if (!meta.hint?.includes('OBSIDIAN_OMNISEARCH_ENABLE=true')) {
+    console.error('hint does not mention the enabling env var — FAIL');
+    process.exit(1);
+  }
+  console.log('  ✓ wrapper attached metadata with the enabling hint');
+}
+
+async function runUnreachable(): Promise<void> {
+  resetServerConfig();
+  process.env.OBSIDIAN_OMNISEARCH_ENABLE = 'true';
+  process.env.OBSIDIAN_OMNISEARCH_BASE_URL = 'http://127.0.0.1:1'; // refused
+  const config = getServerConfig();
+  initObsidianService(config);
+  initOmnisearchService(config);
+  const ctx = createMockContext();
+  try {
+    await obsidianOmnisearch.handler({ query, limit: 1, maxMatchesPerFile: 0 }, ctx);
+    console.error('EXPECTED handler to throw against unreachable upstream — FAIL');
+    process.exit(1);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.log(`thrown error: ${msg.slice(0, 200)}`);
+    const data = (err as { data?: Record<string, unknown> }).data ?? {};
+    console.log(`error.data:   ${JSON.stringify(data)}`);
+    console.log('  ✓ handler propagated an upstream failure');
+  }
+}
+
+switch (scenario) {
+  case 'live':
+    await runLive();
+    break;
+  case 'readpath':
+    await runReadPath();
+    break;
+  case 'disabled':
+    await runDisabled();
+    break;
+  case 'unreachable':
+    await runUnreachable();
+    break;
+  default:
+    console.error(`Unknown scenario '${scenario}'. Use: live | readpath | disabled | unreachable`);
+    process.exit(2);
 }

--- a/src/config/server-config.ts
+++ b/src/config/server-config.ts
@@ -110,6 +110,18 @@ const ServerConfigSchema = z.object({
     .describe(
       'Opt-in flag for the command-palette pair (`obsidian_list_commands` + `obsidian_execute_command`). Off by default — Obsidian commands are opaque and can be destructive.',
     ),
+  enableOmnisearch: envBoolean
+    .default(false)
+    .describe(
+      'Opt-in flag for `obsidian_omnisearch`. Off by default — requires the Omnisearch community plugin with its HTTP server enabled. When false the tool is registered as disabled so operators can see why it is unavailable.',
+    ),
+  omnisearchBaseUrl: z
+    .string()
+    .url()
+    .default('http://127.0.0.1:51361')
+    .describe(
+      'Base URL of the Omnisearch plugin HTTP server. Configure it in Obsidian → Omnisearch settings → "HTTP server". Only consulted when OBSIDIAN_OMNISEARCH_ENABLE=true.',
+    ),
   readPaths: envPathList.describe(
     'Optional vault-relative folder allowlist for read operations. Comma-separated; prefix-based with implicit recursion; case-insensitive; trailing slashes normalized. Unset = full vault.',
   ),
@@ -134,6 +146,8 @@ export function getServerConfig(): ServerConfig {
     verifySsl: 'OBSIDIAN_VERIFY_SSL',
     requestTimeoutMs: 'OBSIDIAN_REQUEST_TIMEOUT_MS',
     enableCommands: 'OBSIDIAN_ENABLE_COMMANDS',
+    enableOmnisearch: 'OBSIDIAN_OMNISEARCH_ENABLE',
+    omnisearchBaseUrl: 'OBSIDIAN_OMNISEARCH_BASE_URL',
     readPaths: 'OBSIDIAN_READ_PATHS',
     writePaths: 'OBSIDIAN_WRITE_PATHS',
     readOnly: 'OBSIDIAN_READ_ONLY',

--- a/src/config/server-config.ts
+++ b/src/config/server-config.ts
@@ -118,9 +118,9 @@ const ServerConfigSchema = z.object({
   omnisearchBaseUrl: z
     .string()
     .url()
-    .default('http://127.0.0.1:51361')
+    .default('http://localhost:51361')
     .describe(
-      'Base URL of the Omnisearch plugin HTTP server. Configure it in Obsidian → Omnisearch settings → "HTTP server". Only consulted when OBSIDIAN_OMNISEARCH_ENABLE=true.',
+      'Base URL of the Omnisearch plugin HTTP server. Defaults to `http://localhost:51361` because on macOS the plugin binds IPv6-only (`[::1]:51361`); `localhost` lets undici happy-eyeballs reach it on either stack. If your platform binds IPv4-only, set `http://127.0.0.1:51361` instead. Configure the port in Obsidian → Omnisearch settings → "HTTP server". Only consulted when OBSIDIAN_OMNISEARCH_ENABLE=true.',
     ),
   readPaths: envPathList.describe(
     'Optional vault-relative folder allowlist for read operations. Comma-separated; prefix-based with implicit recursion; case-insensitive; trailing slashes normalized. Unset = full vault.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,13 @@ import { allPromptDefinitions } from '@/mcp-server/prompts/definitions/index.js'
 import { allResourceDefinitions } from '@/mcp-server/resources/definitions/index.js';
 import {
   commandToolDefinitions,
+  omnisearchToolDefinitions,
   readToolDefinitions,
   writeToolDefinitions,
 } from '@/mcp-server/tools/definitions/index.js';
 import { initObsidianService } from '@/services/obsidian/obsidian-service.js';
 import { PathPolicy } from '@/services/obsidian/path-policy.js';
+import { initOmnisearchService } from '@/services/omnisearch/omnisearch-service.js';
 
 const config = getServerConfig();
 const policy = new PathPolicy(config);
@@ -45,7 +47,16 @@ const commandTools =
         }),
       );
 
-const tools = [...readToolDefinitions, ...writeTools, ...commandTools];
+const omnisearchTools = config.enableOmnisearch
+  ? omnisearchToolDefinitions
+  : omnisearchToolDefinitions.map((def) =>
+      disabledTool(def, {
+        reason: 'Disabled by default — requires the Omnisearch community plugin HTTP server.',
+        hint: 'Set OBSIDIAN_OMNISEARCH_ENABLE=true after installing the Omnisearch plugin and enabling its HTTP server (Settings → Omnisearch → "HTTP server").',
+      }),
+    );
+
+const tools = [...readToolDefinitions, ...writeTools, ...commandTools, ...omnisearchTools];
 
 const { services } = await createApp({
   tools,
@@ -53,6 +64,9 @@ const { services } = await createApp({
   prompts: allPromptDefinitions,
   setup() {
     initObsidianService(config);
+    if (config.enableOmnisearch) {
+      initOmnisearchService(config);
+    }
   },
 });
 
@@ -67,6 +81,7 @@ const bannerCtx = requestContextService.createRequestContext({
   operation: 'startup',
   ...policy.describe(),
   enableCommands: config.enableCommands && !config.readOnly,
+  enableOmnisearch: config.enableOmnisearch,
 });
 services.logger.info('Path policy', bannerCtx);
 if (policy.readOnlyShadowsWritePaths) {

--- a/src/mcp-server/tools/definitions/index.ts
+++ b/src/mcp-server/tools/definitions/index.ts
@@ -1,10 +1,10 @@
 /**
  * @fileoverview Tool registration barrel. Tools are split into read-only and
  * write groups so the entry point can wrap the write set with `disabledTool()`
- * when `OBSIDIAN_READ_ONLY=true`. The command-palette pair is exported
- * separately so the entry point wraps it with `disabledTool()` when either
- * `OBSIDIAN_ENABLE_COMMANDS=false` or `OBSIDIAN_READ_ONLY=true` — keeping this
- * module free of eager config reads.
+ * when `OBSIDIAN_READ_ONLY=true`. The command-palette pair and the Omnisearch
+ * tool are exported separately so the entry point wraps them with
+ * `disabledTool()` when their feature flag is off — keeping this module free
+ * of eager config reads.
  * @module mcp-server/tools/definitions/index
  */
 
@@ -17,6 +17,7 @@ import { obsidianListNotes } from './obsidian-list-notes.tool.js';
 import { obsidianListTags } from './obsidian-list-tags.tool.js';
 import { obsidianManageFrontmatter } from './obsidian-manage-frontmatter.tool.js';
 import { obsidianManageTags } from './obsidian-manage-tags.tool.js';
+import { obsidianOmnisearch } from './obsidian-omnisearch.tool.js';
 import { obsidianOpenInUi } from './obsidian-open-in-ui.tool.js';
 import { obsidianPatchNote } from './obsidian-patch-note.tool.js';
 import { obsidianReplaceInNote } from './obsidian-replace-in-note.tool.js';
@@ -48,3 +49,6 @@ export const baseToolDefinitions = [...readToolDefinitions, ...writeToolDefiniti
 
 /** Command-palette tools — opt-in via `OBSIDIAN_ENABLE_COMMANDS=true`; suppressed by `OBSIDIAN_READ_ONLY=true`. */
 export const commandToolDefinitions = [obsidianListCommands, obsidianExecuteCommand];
+
+/** Omnisearch tool — opt-in via `OBSIDIAN_OMNISEARCH_ENABLE=true`; requires the Omnisearch plugin HTTP server. */
+export const omnisearchToolDefinitions = [obsidianOmnisearch];

--- a/src/mcp-server/tools/definitions/obsidian-omnisearch.tool.ts
+++ b/src/mcp-server/tools/definitions/obsidian-omnisearch.tool.ts
@@ -1,0 +1,202 @@
+/**
+ * @fileoverview obsidian_omnisearch — fast indexed full-text search backed by
+ * the Omnisearch community plugin's HTTP server. Much faster than
+ * `obsidian_search_notes` on large vaults and returns Omnisearch's relevance
+ * scoring, matched-word lists, and excerpts. Path-policy gating reuses the
+ * shared `PathPolicy` so OBSIDIAN_READ_PATHS / OBSIDIAN_READ_ONLY apply
+ * uniformly with other read tools. Caps results at 100 hits with an
+ * `excluded` indicator and clips per-file matches via `maxMatchesPerFile`.
+ * @module mcp-server/tools/definitions/obsidian-omnisearch.tool
+ */
+
+import { tool, z } from '@cyanheads/mcp-ts-core';
+import { JsonRpcErrorCode } from '@cyanheads/mcp-ts-core/errors';
+import { getObsidianService } from '@/services/obsidian/obsidian-service.js';
+import {
+  getOmnisearchService,
+  type OmnisearchHit,
+} from '@/services/omnisearch/omnisearch-service.js';
+
+const HIT_CAP = 100;
+const DEFAULT_MATCHES_PER_FILE = 5;
+const EXCLUSION_HINT =
+  'Narrow your query (more specific terms or a `pathPrefix`) to surface the rest.';
+
+const OmnisearchMatchSchema = z
+  .object({
+    match: z.string().describe('The matched token as it appears in the note.'),
+    offset: z.number().describe('Character offset of the match in the source file.'),
+  })
+  .describe('A single Omnisearch token match within a file.');
+
+const OmnisearchHitSchema = z
+  .object({
+    path: z.string().describe('Vault-relative path of the matching note.'),
+    basename: z.string().describe('Filename without extension.'),
+    score: z.number().describe('Omnisearch relevance score — higher is more relevant.'),
+    foundWords: z
+      .array(z.string())
+      .describe('Distinct query tokens Omnisearch matched in this file.'),
+    matches: z
+      .array(OmnisearchMatchSchema)
+      .describe(
+        'Per-token match offsets in the file. Capped per file by `maxMatchesPerFile`; empty when the cap is 0.',
+      ),
+    excerpt: z
+      .string()
+      .optional()
+      .describe('Short snippet of surrounding text Omnisearch produced for preview.'),
+    truncated: z
+      .boolean()
+      .optional()
+      .describe('True when `matches` was clipped to `maxMatchesPerFile`.'),
+    totalMatches: z
+      .number()
+      .optional()
+      .describe('Total match count in this file before clipping. Present only when `truncated`.'),
+  })
+  .describe('A single Omnisearch hit.');
+
+export const obsidianOmnisearch = tool('obsidian_omnisearch', {
+  description: `Fast indexed full-text search across the vault using the Obsidian Omnisearch community plugin's HTTP server. Supports fuzzy matching, tokenization, and multi-word queries (default AND semantics). Returns hits sorted by Omnisearch relevance score along with matched-word lists and excerpts. Much faster than \`obsidian_search_notes\` on large vaults — prefer it for keyword discovery. Requires the Omnisearch plugin with its HTTP server enabled in Obsidian. Results cap at ${HIT_CAP} hits with an \`excluded\` indicator; per-file matches clip at \`maxMatchesPerFile\`.`,
+  annotations: { readOnlyHint: true, idempotentHint: true },
+  input: z.object({
+    query: z
+      .string()
+      .min(1)
+      .describe(
+        'Search query. Omnisearch tokenizes and fuzzy-matches; multiple words combine with AND by default. Prefix with `+` for required, `-` to exclude (per the plugin syntax).',
+      ),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(HIT_CAP)
+      .default(20)
+      .describe(`Maximum hits to return (1-${HIT_CAP}). Defaults to 20.`),
+    maxMatchesPerFile: z
+      .number()
+      .int()
+      .min(0)
+      .max(50)
+      .default(DEFAULT_MATCHES_PER_FILE)
+      .describe(
+        `Cap on match offsets returned per file (0-50). Set to 0 to drop the \`matches\` arrays entirely and keep only score + excerpt. Defaults to ${DEFAULT_MATCHES_PER_FILE}.`,
+      ),
+    pathPrefix: z
+      .string()
+      .optional()
+      .describe(
+        "Optional vault-relative path prefix filter (e.g. 'Papers/'). Applied client-side after Omnisearch returns hits. Trailing slash is normalized.",
+      ),
+  }),
+  output: z.object({
+    hits: z.array(OmnisearchHitSchema).describe('Matching files, ordered by Omnisearch score.'),
+    excluded: z
+      .object({
+        count: z.number().describe('Hits dropped because the cap was reached.'),
+        hint: z.string().describe('Suggestion for narrowing the query.'),
+      })
+      .optional()
+      .describe('Present when results were truncated to the cap.'),
+    totalUpstream: z
+      .number()
+      .describe('Total hits Omnisearch returned upstream, before path-policy and prefix filters.'),
+  }),
+  auth: ['tool:obsidian_omnisearch:read'],
+  errors: [
+    {
+      reason: 'omnisearch_unreachable',
+      code: JsonRpcErrorCode.ServiceUnavailable,
+      when: 'The Omnisearch HTTP server did not respond or returned a 5xx error.',
+      retryable: true,
+      recovery:
+        'Confirm Obsidian is running with the Omnisearch plugin installed and its HTTP server enabled, then verify OBSIDIAN_OMNISEARCH_BASE_URL matches the plugin port.',
+    },
+  ],
+
+  async handler(input, ctx) {
+    const omni = getOmnisearchService();
+    const policy = getObsidianService().policy;
+
+    const upstream = await omni.search(ctx, input.query);
+    const totalUpstream = upstream.length;
+
+    const prefixRaw = input.pathPrefix;
+    const prefix = prefixRaw ? `${prefixRaw.replace(/^\/+|\/+$/g, '')}/` : '';
+    const prefixed = prefix ? upstream.filter((h) => h.path.startsWith(prefix)) : upstream;
+
+    /**
+     * Path-policy post-filter: reads outside OBSIDIAN_READ_PATHS are dropped
+     * silently, matching the behavior of `obsidian_search_notes`. The
+     * `excluded` indicator only counts hits trimmed by the response cap so
+     * the policy denial count never leaks back to the caller.
+     */
+    const allowed = prefixed.filter((h) => policy.isReadable(h.path));
+
+    const limited = allowed.slice(0, Math.min(input.limit, HIT_CAP));
+    const excluded =
+      allowed.length > limited.length
+        ? { count: allowed.length - limited.length, hint: EXCLUSION_HINT }
+        : undefined;
+
+    const cap = input.maxMatchesPerFile;
+    const hits = limited.map((h) => clipMatches(h, cap));
+
+    return { hits, excluded, totalUpstream };
+  },
+
+  format: (result) => {
+    const lines: string[] = [
+      `**Omnisearch — ${result.hits.length} hits (upstream: ${result.totalUpstream})**`,
+    ];
+    if (result.excluded) {
+      lines.push(`_Excluded ${result.excluded.count} additional hits — ${result.excluded.hint}_`);
+    }
+    if (result.hits.length === 0) {
+      lines.push(
+        '',
+        '_No matches. Try broader terms, drop `pathPrefix`, or confirm the Omnisearch plugin has indexed the vault._',
+      );
+      return [{ type: 'text', text: lines.join('\n') }];
+    }
+    lines.push('');
+    for (const h of result.hits) {
+      const truncFlag = h.truncated === true;
+      const trunc = truncFlag
+        ? ` — truncated, showing first ${h.matches.length} of ${h.totalMatches} matches`
+        : '';
+      lines.push(`### ${h.path} (score: ${h.score.toFixed(2)})${trunc}`);
+      lines.push(`- basename: \`${h.basename}\``);
+      if (h.foundWords.length > 0) {
+        lines.push(`- matched: ${h.foundWords.map((w) => `\`${w}\``).join(', ')}`);
+      }
+      if (h.excerpt) {
+        lines.push(`- excerpt: ${truncate(h.excerpt, 240)}`);
+      }
+      for (const m of h.matches) {
+        lines.push(`  - \`${m.match}\` @ ${m.offset}`);
+      }
+    }
+    return [{ type: 'text', text: lines.join('\n') }];
+  },
+});
+
+function clipMatches(
+  hit: OmnisearchHit,
+  cap: number,
+): OmnisearchHit & { truncated?: boolean; totalMatches?: number } {
+  if (cap === 0) return { ...hit, matches: [] };
+  if (hit.matches.length <= cap) return hit;
+  return {
+    ...hit,
+    matches: hit.matches.slice(0, cap),
+    truncated: true,
+    totalMatches: hit.matches.length,
+  };
+}
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return `${s.slice(0, n)}…`;
+}

--- a/src/services/omnisearch/omnisearch-service.ts
+++ b/src/services/omnisearch/omnisearch-service.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Context } from '@cyanheads/mcp-ts-core';
+import { serviceUnavailable } from '@cyanheads/mcp-ts-core/errors';
 import { httpErrorFromResponse, withRetry } from '@cyanheads/mcp-ts-core/utils';
 import { Agent, type Dispatcher, type RequestInit, fetch as undiciFetch } from 'undici';
 import { getServerConfig, type ServerConfig } from '@/config/server-config.js';
@@ -60,37 +61,56 @@ export class OmnisearchService {
 
   async search(ctx: Context, query: string): Promise<OmnisearchHit[]> {
     const path = `/search?q=${encodeURIComponent(query)}`;
-    const res = await withRetry(
-      async () => {
-        const r = await this.#fetch(`${this.#baseUrl}${path}`, {
-          method: 'GET',
-          dispatcher: this.#dispatcher,
-          signal: ctx.signal,
-        });
-        if (!r.ok) {
-          await this.#throwForStatus(r, path);
-        }
-        return r;
-      },
-      {
-        operation: `omnisearch.GET ${path}`,
-        context: {
-          requestId: ctx.requestId,
-          timestamp: ctx.timestamp,
-          ...(ctx.tenantId !== undefined ? { tenantId: ctx.tenantId } : {}),
-          ...(ctx.traceId !== undefined ? { traceId: ctx.traceId } : {}),
-          ...(ctx.spanId !== undefined ? { spanId: ctx.spanId } : {}),
+    const url = `${this.#baseUrl}${path}`;
+    try {
+      const res = await withRetry(
+        async () => {
+          const r = await this.#fetch(url, {
+            method: 'GET',
+            dispatcher: this.#dispatcher,
+            signal: ctx.signal,
+          });
+          if (!r.ok) {
+            await this.#throwForStatus(r, path, ctx);
+          }
+          return r;
         },
-        baseDelayMs: 200,
-        maxRetries: 3,
-        signal: ctx.signal,
-      },
-    );
-    const body = (await res.json()) as OmnisearchHit[];
-    return Array.isArray(body) ? body : [];
+        {
+          operation: `omnisearch.GET ${path}`,
+          context: {
+            requestId: ctx.requestId,
+            timestamp: ctx.timestamp,
+            ...(ctx.tenantId !== undefined ? { tenantId: ctx.tenantId } : {}),
+            ...(ctx.traceId !== undefined ? { traceId: ctx.traceId } : {}),
+            ...(ctx.spanId !== undefined ? { spanId: ctx.spanId } : {}),
+          },
+          baseDelayMs: 200,
+          maxRetries: 3,
+          signal: ctx.signal,
+        },
+      );
+      const body = (await res.json()) as OmnisearchHit[];
+      return Array.isArray(body) ? body : [];
+    } catch (err) {
+      if (ctx.signal?.aborted) throw err;
+      // Caller cancelled? Bubble. Otherwise re-throw connection / DNS / abort
+      // failures as the contract's `omnisearch_unreachable` reason so the
+      // recovery hint lands on the wire (httpErrorFromResponse already does
+      // this for HTTP-level errors via #throwForStatus).
+      if (err && typeof err === 'object' && 'data' in err) throw err;
+      const msg =
+        err instanceof Error
+          ? `Omnisearch unreachable at ${url}: ${err.message}`
+          : `Omnisearch unreachable at ${url}.`;
+      throw serviceUnavailable(msg, {
+        url,
+        reason: 'omnisearch_unreachable',
+        ...ctx.recoveryFor('omnisearch_unreachable'),
+      });
+    }
   }
 
-  async #throwForStatus(res: UndiciResponse, path: string): Promise<never> {
+  async #throwForStatus(res: UndiciResponse, path: string, ctx: Context): Promise<never> {
     const text = await this.#readBodySafe(res);
     const truncated = text ? (text.length > 500 ? `${text.slice(0, 500)}…` : text) : undefined;
     throw await httpErrorFromResponse(res, {
@@ -98,6 +118,8 @@ export class OmnisearchService {
       captureBody: false,
       data: {
         url: `${this.#baseUrl}${path}`,
+        reason: 'omnisearch_unreachable',
+        ...ctx.recoveryFor('omnisearch_unreachable'),
         ...(truncated !== undefined ? { body: truncated } : {}),
       },
     });

--- a/src/services/omnisearch/omnisearch-service.ts
+++ b/src/services/omnisearch/omnisearch-service.ts
@@ -1,0 +1,136 @@
+/**
+ * @fileoverview Omnisearch HTTP API client. Wraps the Obsidian Omnisearch
+ * plugin's local HTTP server (`/search?q=…`) and classifies upstream errors
+ * for the framework. Plugin docs: https://github.com/scambier/obsidian-omnisearch
+ * @module services/omnisearch/omnisearch-service
+ */
+
+import type { Context } from '@cyanheads/mcp-ts-core';
+import { httpErrorFromResponse, withRetry } from '@cyanheads/mcp-ts-core/utils';
+import { Agent, type Dispatcher, type RequestInit, fetch as undiciFetch } from 'undici';
+import { getServerConfig, type ServerConfig } from '@/config/server-config.js';
+
+type UndiciResponse = Awaited<ReturnType<typeof undiciFetch>>;
+
+/**
+ * Test seam mirroring `ObsidianFetch` in obsidian-service.ts — Bun treats
+ * `undici` as a builtin so module-level `vi.mock('undici')` is a no-op; tests
+ * inject a stub through the constructor instead.
+ */
+export type OmnisearchFetch = (
+  url: string,
+  init: RequestInit & { dispatcher?: Dispatcher; signal?: AbortSignal },
+) => Promise<UndiciResponse>;
+
+export interface OmnisearchMatch {
+  match: string;
+  offset: number;
+}
+
+export interface OmnisearchHit {
+  basename: string;
+  excerpt?: string;
+  foundWords: string[];
+  matches: OmnisearchMatch[];
+  path: string;
+  score: number;
+  vault: string;
+}
+
+export class OmnisearchService {
+  readonly #baseUrl: string;
+  readonly #timeoutMs: number;
+  readonly #dispatcher: Dispatcher;
+  readonly #fetch: OmnisearchFetch;
+
+  constructor(config: ServerConfig, fetchImpl?: OmnisearchFetch) {
+    this.#baseUrl = config.omnisearchBaseUrl.replace(/\/+$/, '');
+    this.#timeoutMs = config.requestTimeoutMs;
+    this.#dispatcher = new Agent({
+      headersTimeout: this.#timeoutMs,
+      bodyTimeout: this.#timeoutMs,
+    });
+    this.#fetch = fetchImpl ?? (undiciFetch as OmnisearchFetch);
+  }
+
+  /** Configured plugin base URL — surfaced to error messages so operators can verify connectivity. */
+  get baseUrl(): string {
+    return this.#baseUrl;
+  }
+
+  async search(ctx: Context, query: string): Promise<OmnisearchHit[]> {
+    const path = `/search?q=${encodeURIComponent(query)}`;
+    const res = await withRetry(
+      async () => {
+        const r = await this.#fetch(`${this.#baseUrl}${path}`, {
+          method: 'GET',
+          dispatcher: this.#dispatcher,
+          signal: ctx.signal,
+        });
+        if (!r.ok) {
+          await this.#throwForStatus(r, path);
+        }
+        return r;
+      },
+      {
+        operation: `omnisearch.GET ${path}`,
+        context: {
+          requestId: ctx.requestId,
+          timestamp: ctx.timestamp,
+          ...(ctx.tenantId !== undefined ? { tenantId: ctx.tenantId } : {}),
+          ...(ctx.traceId !== undefined ? { traceId: ctx.traceId } : {}),
+          ...(ctx.spanId !== undefined ? { spanId: ctx.spanId } : {}),
+        },
+        baseDelayMs: 200,
+        maxRetries: 3,
+        signal: ctx.signal,
+      },
+    );
+    const body = (await res.json()) as OmnisearchHit[];
+    return Array.isArray(body) ? body : [];
+  }
+
+  async #throwForStatus(res: UndiciResponse, path: string): Promise<never> {
+    const text = await this.#readBodySafe(res);
+    const truncated = text ? (text.length > 500 ? `${text.slice(0, 500)}…` : text) : undefined;
+    throw await httpErrorFromResponse(res, {
+      service: 'Obsidian Omnisearch',
+      captureBody: false,
+      data: {
+        url: `${this.#baseUrl}${path}`,
+        ...(truncated !== undefined ? { body: truncated } : {}),
+      },
+    });
+  }
+
+  async #readBodySafe(res: UndiciResponse): Promise<string> {
+    try {
+      return await res.text();
+    } catch {
+      return '';
+    }
+  }
+}
+
+let _service: OmnisearchService | undefined;
+
+export function initOmnisearchService(
+  config: ServerConfig = getServerConfig(),
+  fetchImpl?: OmnisearchFetch,
+): void {
+  _service = new OmnisearchService(config, fetchImpl);
+}
+
+/** Test-only: directly install an instance (e.g., one backed by a stub fetch). */
+export function setOmnisearchService(service: OmnisearchService | undefined): void {
+  _service = service;
+}
+
+export function getOmnisearchService(): OmnisearchService {
+  if (!_service) {
+    throw new Error(
+      'OmnisearchService not initialized — set OBSIDIAN_OMNISEARCH_ENABLE=true and call initOmnisearchService() in setup().',
+    );
+  }
+  return _service;
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -29,6 +29,8 @@ export function makeTestConfig(overrides: Partial<ServerConfig> = {}): ServerCon
     verifySsl: false,
     requestTimeoutMs: 5_000,
     enableCommands: false,
+    enableOmnisearch: false,
+    omnisearchBaseUrl: 'http://omnisearch.test',
     readPaths: undefined,
     writePaths: undefined,
     readOnly: false,

--- a/tests/tools/obsidian-omnisearch.test.ts
+++ b/tests/tools/obsidian-omnisearch.test.ts
@@ -1,0 +1,274 @@
+/**
+ * @fileoverview Handler tests for obsidian_omnisearch — exercises the full
+ * pipeline (input parse → service fetch → path-policy filter → cap + clip →
+ * format()) against a stub fetch, plus the omnisearch_unreachable error
+ * contract on transport failures.
+ * @module tests/tools/obsidian-omnisearch.test
+ */
+
+import { JsonRpcErrorCode } from '@cyanheads/mcp-ts-core/errors';
+import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
+import { afterEach, describe, expect, it } from 'vitest';
+import { obsidianOmnisearch } from '@/mcp-server/tools/definitions/obsidian-omnisearch.tool.js';
+import {
+  type ObsidianFetch,
+  ObsidianService,
+  setObsidianService,
+} from '@/services/obsidian/obsidian-service.js';
+import {
+  type OmnisearchFetch,
+  OmnisearchService,
+  setOmnisearchService,
+} from '@/services/omnisearch/omnisearch-service.js';
+import { makeTestConfig, setupHarness } from '../helpers.js';
+
+const obsidianHarness = setupHarness();
+
+interface MockHit {
+  basename: string;
+  excerpt?: string;
+  foundWords: string[];
+  matches: Array<{ match: string; offset: number }>;
+  path: string;
+  score: number;
+  vault: string;
+}
+
+function installOmnisearch(hits: MockHit[] | (() => Response)): void {
+  const fetchImpl: OmnisearchFetch = async () => {
+    if (typeof hits === 'function') return hits() as unknown as Response;
+    return new Response(JSON.stringify(hits), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+  setOmnisearchService(new OmnisearchService(makeTestConfig(), fetchImpl));
+}
+
+function mockHit(over: Partial<MockHit> = {}): MockHit {
+  return {
+    basename: 'note',
+    foundWords: ['x'],
+    matches: [{ match: 'x', offset: 0 }],
+    path: 'note.md',
+    score: 1,
+    vault: 'test',
+    ...over,
+  };
+}
+
+afterEach(() => {
+  setOmnisearchService(undefined);
+});
+
+describe('obsidian_omnisearch / happy path', () => {
+  it('returns upstream hits with score ordering preserved', async () => {
+    installOmnisearch([mockHit({ path: 'a.md', score: 10 }), mockHit({ path: 'b.md', score: 5 })]);
+    const out = await obsidianOmnisearch.handler(
+      obsidianOmnisearch.input.parse({ query: 'x' }),
+      createMockContext(),
+    );
+    expect(out.totalUpstream).toBe(2);
+    expect(out.hits.map((h) => h.path)).toEqual(['a.md', 'b.md']);
+    expect(out.excluded).toBeUndefined();
+  });
+
+  it('preserves basename, excerpt, foundWords', async () => {
+    installOmnisearch([
+      mockHit({
+        path: 'Projects/Plan.md',
+        basename: 'Plan',
+        excerpt: 'a snippet',
+        foundWords: ['plan', 'planning'],
+      }),
+    ]);
+    const out = await obsidianOmnisearch.handler(
+      obsidianOmnisearch.input.parse({ query: 'plan' }),
+      createMockContext(),
+    );
+    expect(out.hits[0]).toMatchObject({
+      basename: 'Plan',
+      excerpt: 'a snippet',
+      foundWords: ['plan', 'planning'],
+    });
+  });
+
+  it('renders format() with parity to structuredContent', async () => {
+    installOmnisearch([
+      mockHit({
+        path: 'Projects/Plan.md',
+        basename: 'Plan',
+        excerpt: 'snippet',
+        score: 2.5,
+      }),
+    ]);
+    const out = await obsidianOmnisearch.handler(
+      obsidianOmnisearch.input.parse({ query: 'plan' }),
+      createMockContext(),
+    );
+    const blocks = obsidianOmnisearch.format!(out);
+    const text = (blocks[0] as { text: string }).text;
+    expect(text).toContain('Projects/Plan.md');
+    expect(text).toContain('2.50');
+    expect(text).toContain('`Plan`');
+    expect(text).toContain('snippet');
+  });
+});
+
+describe('obsidian_omnisearch / caps and clipping', () => {
+  it('caps hits at `limit` and surfaces an excluded indicator', async () => {
+    const hits = Array.from({ length: 7 }, (_, i) => mockHit({ path: `${i}.md`, score: 7 - i }));
+    installOmnisearch(hits);
+    const out = await obsidianOmnisearch.handler(
+      obsidianOmnisearch.input.parse({ query: 'x', limit: 3 }),
+      createMockContext(),
+    );
+    expect(out.hits).toHaveLength(3);
+    expect(out.excluded?.count).toBe(4);
+    expect(out.totalUpstream).toBe(7);
+  });
+
+  it('clips per-file matches at maxMatchesPerFile with truncated + totalMatches', async () => {
+    const manyMatches = Array.from({ length: 12 }, (_, i) => ({
+      match: `t${i}`,
+      offset: i,
+    }));
+    installOmnisearch([mockHit({ path: 'busy.md', matches: manyMatches })]);
+    const out = await obsidianOmnisearch.handler(
+      obsidianOmnisearch.input.parse({ query: 'x', maxMatchesPerFile: 3 }),
+      createMockContext(),
+    );
+    expect(out.hits[0]?.matches).toHaveLength(3);
+    expect(out.hits[0]?.truncated).toBe(true);
+    expect(out.hits[0]?.totalMatches).toBe(12);
+  });
+
+  it('drops the matches array entirely when maxMatchesPerFile=0', async () => {
+    installOmnisearch([
+      mockHit({
+        matches: [
+          { match: 'a', offset: 0 },
+          { match: 'b', offset: 1 },
+        ],
+      }),
+    ]);
+    const out = await obsidianOmnisearch.handler(
+      obsidianOmnisearch.input.parse({ query: 'x', maxMatchesPerFile: 0 }),
+      createMockContext(),
+    );
+    expect(out.hits[0]?.matches).toEqual([]);
+    expect(out.hits[0]?.truncated).toBeUndefined();
+  });
+
+  it('leaves truncated/totalMatches undefined when matches fit the cap', async () => {
+    installOmnisearch([mockHit({ matches: [{ match: 'a', offset: 0 }] })]);
+    const out = await obsidianOmnisearch.handler(
+      obsidianOmnisearch.input.parse({ query: 'x', maxMatchesPerFile: 5 }),
+      createMockContext(),
+    );
+    expect(out.hits[0]?.truncated).toBeUndefined();
+    expect(out.hits[0]?.totalMatches).toBeUndefined();
+  });
+});
+
+describe('obsidian_omnisearch / pathPrefix filter', () => {
+  it('applies pathPrefix client-side', async () => {
+    installOmnisearch([
+      mockHit({ path: 'Papers/a.md' }),
+      mockHit({ path: 'Notes/b.md' }),
+      mockHit({ path: 'Papers/sub/c.md' }),
+    ]);
+    const out = await obsidianOmnisearch.handler(
+      obsidianOmnisearch.input.parse({ query: 'x', pathPrefix: 'Papers/' }),
+      createMockContext(),
+    );
+    expect(out.hits.map((h) => h.path)).toEqual(['Papers/a.md', 'Papers/sub/c.md']);
+    expect(out.totalUpstream).toBe(3);
+  });
+
+  it('normalizes leading and trailing slashes on pathPrefix', async () => {
+    installOmnisearch([mockHit({ path: 'Papers/a.md' }), mockHit({ path: 'Notes/b.md' })]);
+    const out = await obsidianOmnisearch.handler(
+      obsidianOmnisearch.input.parse({ query: 'x', pathPrefix: '/Papers' }),
+      createMockContext(),
+    );
+    expect(out.hits.map((h) => h.path)).toEqual(['Papers/a.md']);
+  });
+});
+
+describe('obsidian_omnisearch / path-policy', () => {
+  it('drops hits outside readPaths silently and preserves totalUpstream', async () => {
+    /**
+     * Replace the harness ObsidianService with one scoped to `public` so
+     * `policy.isReadable` rejects `secret/*` paths. We still need an
+     * Obsidian fetch impl, but the test never exercises it.
+     */
+    const obsFetch: ObsidianFetch = async () => {
+      throw new Error('Obsidian service should not be hit by this test');
+    };
+    setObsidianService(new ObsidianService(makeTestConfig({ readPaths: ['public'] }), obsFetch));
+    installOmnisearch([
+      mockHit({ path: 'public/a.md' }),
+      mockHit({ path: 'secret/b.md' }),
+      mockHit({ path: 'public/sub/c.md' }),
+    ]);
+    const out = await obsidianOmnisearch.handler(
+      obsidianOmnisearch.input.parse({ query: 'x' }),
+      createMockContext(),
+    );
+    expect(out.hits.map((h) => h.path)).toEqual(['public/a.md', 'public/sub/c.md']);
+    expect(out.totalUpstream).toBe(3);
+    expect(out.excluded).toBeUndefined();
+  });
+});
+
+describe('obsidian_omnisearch / upstream failures', () => {
+  it('tags HTTP 503 with the omnisearch_unreachable reason', async () => {
+    setOmnisearchService(
+      new OmnisearchService(makeTestConfig(), async () => new Response('boom', { status: 503 })),
+    );
+    // Ensure the obsidian service is wired (setupHarness already does this).
+    obsidianHarness.current();
+    await expect(
+      obsidianOmnisearch.handler(
+        obsidianOmnisearch.input.parse({ query: 'x' }),
+        createMockContext({ errors: obsidianOmnisearch.errors }),
+      ),
+    ).rejects.toMatchObject({
+      code: JsonRpcErrorCode.ServiceUnavailable,
+      data: { reason: 'omnisearch_unreachable' },
+    });
+  });
+
+  it('tags transport failures with the omnisearch_unreachable reason', async () => {
+    setOmnisearchService(
+      new OmnisearchService(makeTestConfig(), async () => {
+        throw new Error('ECONNREFUSED 127.0.0.1:1');
+      }),
+    );
+    obsidianHarness.current();
+    await expect(
+      obsidianOmnisearch.handler(
+        obsidianOmnisearch.input.parse({ query: 'x' }),
+        createMockContext({ errors: obsidianOmnisearch.errors }),
+      ),
+    ).rejects.toMatchObject({
+      code: JsonRpcErrorCode.ServiceUnavailable,
+      data: { reason: 'omnisearch_unreachable' },
+    });
+  });
+});
+
+describe('obsidian_omnisearch / empty state', () => {
+  it('renders a guidance message when there are no hits', async () => {
+    installOmnisearch([]);
+    const out = await obsidianOmnisearch.handler(
+      obsidianOmnisearch.input.parse({ query: 'x' }),
+      createMockContext(),
+    );
+    expect(out.hits).toEqual([]);
+    expect(out.totalUpstream).toBe(0);
+    const blocks = obsidianOmnisearch.format!(out);
+    expect((blocks[0] as { text: string }).text).toMatch(/no matches/i);
+  });
+});


### PR DESCRIPTION
## Summary

Port of the Omnisearch idea from #37 onto the current v3.1.x framework (`@cyanheads/mcp-ts-core`). #37 is stale (~1 month, built against the pre-framework template) so the diff there no longer applies cleanly — this rewrites the tool against the current `tool()` builder, single-file definitions, error contracts, and `PathPolicy` gating.

Adds a single new tool: **`obsidian_omnisearch`** — fast indexed full-text search backed by the [Obsidian Omnisearch](https://github.com/scambier/obsidian-omnisearch) community plugin's HTTP server. Much faster than `obsidian_search_notes` on large vaults; returns Omnisearch relevance scores, matched-word lists, and excerpts.

The tool is **opt-in**: when `OBSIDIAN_OMNISEARCH_ENABLE=false` (default) it's registered as `disabledTool()` so operators can see why it's unavailable and how to enable it.

## Changes

- `src/services/omnisearch/omnisearch-service.ts` (new) — init/accessor service mirroring `obsidian-service`:
  - Undici fetch with per-instance dispatcher + headers/body timeout.
  - `ctx.signal` propagated for cancellation/timeout.
  - `withRetry` (3 attempts, 200ms base) on transient failures.
  - Error classification via `httpErrorFromResponse` so 5xx/timeout become `ServiceUnavailable`/`Timeout` consistently with the rest of the server.
  - `OmnisearchFetch` test seam — Bun ignores module-level `vi.mock('undici')`.
- `src/mcp-server/tools/definitions/obsidian-omnisearch.tool.ts` (new) — `tool()` builder with:
  - `HIT_CAP = 100` hits, `excluded` indicator when truncated, plus `totalUpstream` so callers see the raw count.
  - Per-file match clipping via `maxMatchesPerFile` (0-50; 0 drops match arrays entirely).
  - Optional client-side `pathPrefix` filter.
  - Path-policy post-filter via `PathPolicy.isReadable` so `OBSIDIAN_READ_PATHS` / `OBSIDIAN_READ_ONLY` apply uniformly with `obsidian_search_notes` (hits dropped by policy are not counted in `excluded` to avoid leaking the denial count).
  - Error contract: `omnisearch_unreachable` (retryable) with a concrete recovery hint.
  - `format()` content-complete vs `structuredContent` (passes the format-parity linter).
- `src/config/server-config.ts` — two new env vars:
  - `OBSIDIAN_OMNISEARCH_ENABLE` (default \`false\`) — opt-in flag.
  - `OBSIDIAN_OMNISEARCH_BASE_URL` (default \`http://127.0.0.1:51361\`) — plugin port.
- `src/mcp-server/tools/definitions/index.ts` — exports `omnisearchToolDefinitions` as a separate opt-in group (same pattern as `commandToolDefinitions`); no eager config reads in the barrel.
- `src/index.ts` — wraps with `disabledTool()` when the flag is off, calls `initOmnisearchService(config)` in `setup()`, and echoes `enableOmnisearch` in the startup banner.

## Design notes

- **Why opt-in.** The Omnisearch plugin is optional and not installed in every vault. Defaulting to disabled keeps the tool surface honest (`tools/list` shows it as disabled with a hint, instead of throwing at first call).
- **Why path-policy filter, not a separate scope.** Reusing `PathPolicy.isReadable` means the same allowlist works across all read tools. No new env vars to learn.
- **Why drop `package-lock.json` and `Dockerfile` edits from #37.** This repo runs on Bun (`bun.lock`); the lockfile and Dockerfile churn in #37 doesn't apply here.
- **Why omit the other tools from #37.** #37 also added `obsidian_context_blocks`, `obsidian_find_related`, `obsidian_semantic_search` (the last backed by a Smart Connections service). Each is a separate design question (different plugin dependency, different scope), so this PR ships just Omnisearch. Happy to open follow-up PRs for the others if you're interested.

## Test plan

- [x] `bun run devcheck` (lint, format, typecheck, MCP defs linter, security, deps, changelog) — green
- [ ] Local smoke test against a vault with the Omnisearch plugin's HTTP server enabled — query returns hits, score ordering matches the plugin, `maxMatchesPerFile=0` drops match arrays.
- [ ] `OBSIDIAN_READ_PATHS` allowlist correctly drops hits outside the scope.
- [ ] `OBSIDIAN_OMNISEARCH_ENABLE=false` registers the tool as disabled with the right hint.
- [ ] Plugin offline → `omnisearch_unreachable` error with the recovery hint.

Closes #37 if you'd like to absorb it; otherwise feel free to leave it open and treat this as a fresh proposal.