### PR TITLE
feat!: v3.2.0 — Omnisearch + cursor pagination on obsidian_search_notes; list_commands nameRegex; PATCH headers for Local REST API v4.0.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project. Each entry links to its full per-version file in [changelog/](changelog/).
 
+## [3.2.0](changelog/3.2.x/3.2.0.md) — 2026-05-17 · ⚠️ Breaking
+
+`obsidian_search_notes` gains BM25-ranked Omnisearch mode (auto-detected) and MCP-spec cursor pagination across all branches; `obsidian_list_commands` gains a `nameRegex` filter; PATCH headers track markdown-patch 1.0 from Local REST API v4.0.0+.
+
 ## [3.1.11](changelog/3.1.x/3.1.11.md) — 2026-05-16 · 🛡️ Security
 
 Path-traversal hardening on the URL boundary + Windows-style separator parity across `PathPolicy` and `envPathList`. `obsidian_list_tags` gains an optional `nameRegex` filter with ReDoS guards.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Agent Protocol
 
 **Server:** obsidian-mcp-server
-**Version:** 3.1.10
+**Version:** 3.2.0
 **Framework:** [@cyanheads/mcp-ts-core](https://www.npmjs.com/package/@cyanheads/mcp-ts-core) `^0.9.1`
 **Engines:** Bun ≥1.3.11, Node ≥24.0.0
 
@@ -247,7 +247,7 @@ src/
   mcp-server/
     tools/definitions/
       _shared/schemas.ts                # Shared TargetSchema + SectionSchema reused across tools
-      index.ts                          # baseToolDefinitions[] + conditional commandToolDefinitions[]
+      index.ts                          # read/write/command tool sets + buildSearchNotesTool factory (Omnisearch-aware)
       obsidian-*.tool.ts                # 14 tool definitions (12 base + 2 opt-in command-palette pair)
     resources/definitions/
       index.ts                          # allResourceDefinitions[]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <div align="center">
 
-[![npm](https://img.shields.io/npm/v/obsidian-mcp-server?style=flat-square&logo=npm&logoColor=white)](https://www.npmjs.com/package/obsidian-mcp-server) [![Version](https://img.shields.io/badge/Version-3.1.11-blue.svg?style=flat-square)](./CHANGELOG.md) [![Framework](https://img.shields.io/badge/Built%20on-@cyanheads/mcp--ts--core-259?style=flat-square)](https://www.npmjs.com/package/@cyanheads/mcp-ts-core) [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-^1.29.0-green.svg?style=flat-square)](https://modelcontextprotocol.io/)
+[![npm](https://img.shields.io/npm/v/obsidian-mcp-server?style=flat-square&logo=npm&logoColor=white)](https://www.npmjs.com/package/obsidian-mcp-server) [![Version](https://img.shields.io/badge/Version-3.2.0-blue.svg?style=flat-square)](./CHANGELOG.md) [![Framework](https://img.shields.io/badge/Built%20on-@cyanheads/mcp--ts--core-259?style=flat-square)](https://www.npmjs.com/package/@cyanheads/mcp-ts-core) [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-^1.29.0-green.svg?style=flat-square)](https://modelcontextprotocol.io/)
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg?style=flat-square)](./LICENSE) [![TypeScript](https://img.shields.io/badge/TypeScript-^6.0.3-3178C6.svg?style=flat-square)](https://www.typescriptlang.org/) [![Bun](https://img.shields.io/badge/Bun-v1.3.11-blueviolet.svg?style=flat-square)](https://bun.sh/)
 
@@ -25,7 +25,7 @@ Fourteen tools grouped by shape — readers fetch notes and metadata, writers cr
 | `obsidian_list_notes` | List notes and subdirectories at a vault path with a recursive walk (default depth 2 — structural overview; max 20) bounded by a 1000-entry cap. Optional `extension` and `nameRegex` filters apply across the tree; regex-filtered directories are skipped without recursing into them. Returns flat `entries[]` plus a box-drawing tree in the rendered output; per-directory `truncated: true` flags where the depth limit cut off recursion. |
 | `obsidian_list_tags` | List every tag found across the vault with usage counts, including hierarchical parents. Optional `nameRegex` post-filters the result set (length-capped, nested-quantifier-guarded). |
 | `obsidian_list_commands` | List Obsidian command-palette commands available for execution. **Opt-in via `OBSIDIAN_ENABLE_COMMANDS=true`** (paired with `obsidian_execute_command`). |
-| `obsidian_search_notes` | Search the vault by text, Dataview DQL, or JSONLogic. Text-mode matches return surrounding context windows (`contextLength`) — capped at 100 hits with overflow indicator. |
+| `obsidian_search_notes` | Search the vault by text, JSONLogic, or — when the Omnisearch plugin's HTTP server is reachable at startup — BM25-ranked Omnisearch. Results paginate via opaque cursors (`nextCursor` + `totalCount`); text-mode hits return surrounding context windows (`contextLength`) and clip per-file at `maxMatchesPerHit`. |
 | `obsidian_write_note` | Create a note, replace a single section in place, or — with `overwrite: true` — clobber an existing file. Refuses whole-file writes against an existing path by default. |
 | `obsidian_append_to_note` | Append content to a note. Without `section` it creates the file if missing — your content becomes the entire file. With `section`, appends to that heading/block/frontmatter (PATCH; the file must exist). |
 | `obsidian_patch_note` | Surgical `append` / `prepend` / `replace` against a heading, block reference, or frontmatter field. |
@@ -51,13 +51,13 @@ Pair the document-map projection with `obsidian_patch_note` to discover edit tar
 
 ### `obsidian_search_notes`
 
-Three search modes selected by `mode`:
+Up to three search modes selected by `mode`:
 
-- `text` — substring match with surrounding context windows. `contextLength` controls characters of context per side of each match (default 100; bump it for more context per hit). Optional `pathPrefix` filter (text mode only — passing `pathPrefix` in `dataview` or `jsonlogic` mode is rejected with `path_prefix_invalid_mode`).
-- `dataview` — Dataview DQL (`TABLE …`) for path/date/metadata queries; `file.mtime`, `file.path`, etc. are queryable
+- `text` — substring match with surrounding context windows. `contextLength` controls characters of context per side of each match (default 100; bump it for more context per hit). Optional `pathPrefix` filter (text mode only — passing `pathPrefix` in any other mode is rejected with `path_prefix_invalid_mode`).
 - `jsonlogic` — JSONLogic tree evaluated against `path`, `content`, `frontmatter.<key>`, `tags`, and `stat.{ctime,mtime,size}`; custom `glob` and `regexp` operators
+- `omnisearch` — BM25-ranked search via the community [Omnisearch](https://github.com/scambier/obsidian-omnisearch) plugin. Supports quoted phrases, `-exclusion`, `path:` / `ext:` filters, typo tolerance, and PDF + OCR coverage (via [Text Extractor](https://github.com/scambier/obsidian-text-extractor)). Only present in the mode enum when the plugin's HTTP server is reachable at startup; the upstream hard-caps results at 50 — narrow the query to surface more (the response carries `truncated: true` when the cap was likely hit).
 
-Results are capped at 100 hits. When the upstream returns more, an `excluded` indicator surfaces the overflow count and a hint to narrow the query. Text-mode hits are additionally clipped per file at `maxMatchesPerHit` (default 10) so a single match-heavy note can't blow the response budget — clipped hits carry `truncated: true` and `totalMatches`.
+Results paginate via opaque cursors per the [MCP 2025-06-18 spec](https://modelcontextprotocol.io/specification/2025-06-18/utils/pagination): omit `cursor` for the first page, then pass `nextCursor` from the prior response. Every result carries `totalCount` (post-path-policy, pre-pagination); `nextCursor` is omitted on the last page. Text-mode hits are additionally clipped per file at `maxMatchesPerHit` (default 10) so a single match-heavy note can't blow the response budget — clipped hits carry `truncated: true` and `totalMatches`.
 
 ---
 
@@ -188,7 +188,7 @@ Obsidian-specific:
 - Wraps the [Obsidian Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) plugin — typed client, deterministic error mapping
 - Section-aware editing across headings, block references, and frontmatter fields via `PATCH`-with-target operations
 - Tag reconciliation across both representations: frontmatter `tags:` array and inline `#tag` syntax (skipping fenced code blocks)
-- Search across three modes: text, Dataview DQL, JSONLogic — with overflow indicator when results exceed the 100-hit cap
+- Search across up to three modes: text, JSONLogic, and (when the plugin is reachable) BM25-ranked Omnisearch — cursor-paginated per the MCP 2025-06-18 spec, with per-file match clipping in text mode
 - Optional human-in-the-loop confirmation for destructive deletes via `ctx.elicit`
 - Folder-scoped read/write permissions via `OBSIDIAN_READ_PATHS` / `OBSIDIAN_WRITE_PATHS` and a global `OBSIDIAN_READ_ONLY` kill switch — denies are typed `path_forbidden` with the active scope echoed back in the error data
 - Opt-in command-palette pair (`obsidian_list_commands` + `obsidian_execute_command`) — registered only when `OBSIDIAN_ENABLE_COMMANDS=true`
@@ -244,7 +244,7 @@ MCP_TRANSPORT_TYPE=http OBSIDIAN_API_KEY=... bun run start:http
 ### Prerequisites
 
 - [Bun v1.3.11](https://bun.sh/) or higher (or Node.js v24+).
-- The [Obsidian Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) plugin installed and enabled in your vault. Generate an API key in **Settings → Community Plugins → Local REST API** and copy it into `OBSIDIAN_API_KEY`.
+- The [Obsidian Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) plugin **v4.0.0 or later** installed and enabled in your vault. Generate an API key in **Settings → Community Plugins → Local REST API** and copy it into `OBSIDIAN_API_KEY`.
 - This server defaults to `http://127.0.0.1:27123` for simplicity. Enable **"Non-encrypted (HTTP) Server"** in the plugin settings to use it. To use the always-on HTTPS port instead, set `OBSIDIAN_BASE_URL=https://127.0.0.1:27124`; the plugin's self-signed cert is handled by `OBSIDIAN_VERIFY_SSL=false` (the default).
 
 ### Installation
@@ -286,6 +286,7 @@ MCP_TRANSPORT_TYPE=http OBSIDIAN_API_KEY=... bun run start:http
 | `OBSIDIAN_READ_PATHS` | Comma-separated vault-relative folder allowlist for read operations. Prefix-based with implicit recursion; case-insensitive; trailing slashes normalized. Unset = full vault. Write paths are implicitly readable. | unset |
 | `OBSIDIAN_WRITE_PATHS` | Comma-separated vault-relative folder allowlist for write operations. Same syntax as `OBSIDIAN_READ_PATHS`. Unset = full vault. | unset |
 | `OBSIDIAN_READ_ONLY` | Global kill switch. When `true`, denies every write regardless of `OBSIDIAN_WRITE_PATHS`, and suppresses the `OBSIDIAN_ENABLE_COMMANDS` pair (commands can mutate). | `false` |
+| `OBSIDIAN_OMNISEARCH_URL` | Override URL for the [Omnisearch](https://github.com/scambier/obsidian-omnisearch) plugin's HTTP server. When unset, derives from `OBSIDIAN_BASE_URL` host with port `51361` (falling back to `http://localhost:51361`). Probed once at startup — if reachable, the `omnisearch` mode is added to `obsidian_search_notes`; otherwise it's omitted from the tool schema. Restart the server to re-probe. | derived |
 | `MCP_TRANSPORT_TYPE` | Transport: `stdio` or `http`. | `stdio` |
 | `MCP_HTTP_HOST` | Host for the HTTP server. | `127.0.0.1` |
 | `MCP_HTTP_PORT` | Port for the HTTP server. | `3010` |

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ Fourteen tools grouped by shape — readers fetch notes and metadata, writers cr
 | Tool Name | Description |
 |:----------|:------------|
 | `obsidian_get_note` | Read a note as raw content, full structured form (content + frontmatter + tags + stat, with optional outgoing links), structural document map, or a single section. |
-| `obsidian_list_notes` | List notes and subdirectories at a vault path with a recursive walk (default depth 2 — structural overview; max 20) bounded by a 1000-entry cap. Optional `extension` and `nameRegex` filters apply across the tree; regex-filtered directories are skipped without recursing into them. Returns flat `entries[]` plus a box-drawing tree in the rendered output; per-directory `truncated: true` flags where the depth limit cut off recursion. |
-| `obsidian_list_tags` | List every tag found across the vault with usage counts, including hierarchical parents. Optional `nameRegex` post-filters the result set (length-capped, nested-quantifier-guarded). |
-| `obsidian_list_commands` | List Obsidian command-palette commands available for execution. **Opt-in via `OBSIDIAN_ENABLE_COMMANDS=true`** (paired with `obsidian_execute_command`). |
-| `obsidian_search_notes` | Search the vault by text, JSONLogic, or — when the Omnisearch plugin's HTTP server is reachable at startup — BM25-ranked Omnisearch. Results paginate via opaque cursors (`nextCursor` + `totalCount`); text-mode hits return surrounding context windows (`contextLength`) and clip per-file at `maxMatchesPerHit`. |
+| `obsidian_list_notes` | List notes and subdirectories under a vault path. Recursive walk (default depth 2, max depth 20; 1000-entry cap) with optional `extension` and `nameRegex` filters. |
+| `obsidian_list_tags` | List every tag found across the vault with usage counts, including hierarchical parents. Optional `nameRegex` post-filters the result set. |
+| `obsidian_list_commands` | List Obsidian command-palette commands, optionally filtered by `nameRegex` on display name. **Opt-in via `OBSIDIAN_ENABLE_COMMANDS=true`** (paired with `obsidian_execute_command`). |
+| `obsidian_search_notes` | Search the vault by text, JSONLogic, or BM25-ranked Omnisearch (when the plugin is reachable). Results paginate via opaque cursors. |
 | `obsidian_write_note` | Create a note, replace a single section in place, or — with `overwrite: true` — clobber an existing file. Refuses whole-file writes against an existing path by default. |
-| `obsidian_append_to_note` | Append content to a note. Without `section` it creates the file if missing — your content becomes the entire file. With `section`, appends to that heading/block/frontmatter (PATCH; the file must exist). |
+| `obsidian_append_to_note` | Append content to a note. Without `section`, creates the file if missing. With `section`, appends to a specific heading, block, or frontmatter field (file must exist). |
 | `obsidian_patch_note` | Surgical `append` / `prepend` / `replace` against a heading, block reference, or frontmatter field. |
-| `obsidian_replace_in_note` | Body-wide search-replace inside a single note. Literal or regex matching, with `wholeWord`, `flexibleWhitespace`, `caseSensitive`, `replaceAll`, and `$1`/`$&` capture groups. |
+| `obsidian_replace_in_note` | Body-wide search-replace inside a single note. Literal or regex matching with whole-word, whitespace-flexible, and case-sensitivity options; supports capture-group replacement. |
 | `obsidian_manage_frontmatter` | Atomic `get` / `set` / `delete` on a single frontmatter key. |
 | `obsidian_manage_tags` | Add, remove, or list tags — reconciles frontmatter `tags:` and inline `#tag` syntax. |
 | `obsidian_delete_note` | Permanently delete a note. Elicits human confirmation when the client supports it. |

--- a/changelog/3.2.x/3.2.0.md
+++ b/changelog/3.2.x/3.2.0.md
@@ -31,7 +31,7 @@ Two new agent-facing affordances on `obsidian_search_notes` ranked search and pr
 
 ## Removed
 
-- **`obsidian_search_notes` `dataview` mode** — DQL support was a thin pass-through to a single Local REST API endpoint that overlaps with `jsonlogic` for the queries agents actually issue (path/date/metadata filters). Removing it tightens the mode enum so the LLM has fewer near-duplicate choices, and frees the slot for `omnisearch`. Use `jsonlogic` for path/frontmatter/stat filtering, or `omnisearch` for ranked relevance.
+- **`obsidian_search_notes` `dataview` mode** — [Local REST API v4.0.0 removed Dataview DQL search support](https://github.com/coddingtonbear/obsidian-local-rest-api/releases/tag/4.0.0); the mode is gone with it. Use `jsonlogic` for path/frontmatter/stat filtering, or `omnisearch` for ranked relevance.
 - **`ObsidianService.searchDataview(ctx, dql)`** — sole caller removed with the mode. The `application/vnd.olrapi.dataview.dql+txt` content type constant also goes.
 - **`obsidian_search_notes` `excluded` overflow indicator** — replaced by `totalCount` + `nextCursor`. The `EXCLUSION_HINT` constant is removed.
 
@@ -43,7 +43,7 @@ Two new agent-facing affordances on `obsidian_search_notes` ranked search and pr
 
 | Before | After |
 |:--|:--|
-| `obsidian_search_notes` with `mode: 'dataview'` | Switch to `mode: 'jsonlogic'` (path / frontmatter / stat filters) or `mode: 'omnisearch'` (ranked relevance, when reachable). |
+| `obsidian_search_notes` with `mode: 'dataview'` | Removed upstream in Local REST API v4.0.0 (Dataview DQL search). Switch to `mode: 'jsonlogic'` (path / frontmatter / stat filters) or `mode: 'omnisearch'` (ranked relevance, when reachable). |
 | Reading `result.excluded.count` | Read `result.totalCount` and check whether `result.nextCursor` is set. |
 | Paging through > 100 hits | Pass `cursor: result.nextCursor` on the next call; the page size is server-determined (50 default, 200 max). |
 | Sending `Apply-If-Content-Preexists` against Local REST API < 4.0.0 | Upgrade the plugin to v4.0.0 or later. The header was renamed upstream; the wire format is incompatible with older builds. |

--- a/changelog/3.2.x/3.2.0.md
+++ b/changelog/3.2.x/3.2.0.md
@@ -1,0 +1,49 @@
+---
+summary: "`obsidian_search_notes` gains BM25-ranked Omnisearch mode (auto-detected) and MCP-spec cursor pagination across all branches; `obsidian_list_commands` gains a `nameRegex` filter; PATCH headers track markdown-patch 1.0 from Local REST API v4.0.0+."
+breaking: true
+security: false
+---
+
+# 3.2.0 — 2026-05-17
+
+Two new agent-facing affordances on `obsidian_search_notes` ranked search and proper pagination; one quality-of-life filter on `obsidian_list_commands`; and a wire-format catch-up for the Local REST API v4.0.0 markdown-patch 1.0 header rename. Minimum supported plugin floor is now v4.0.0.
+
+## Added
+
+- **`obsidian_search_notes` `omnisearch` mode** — BM25-ranked search via the community [Omnisearch](https://github.com/scambier/obsidian-omnisearch) plugin. Supports quoted phrases, `-exclusion`, `path:` / `ext:` filters, typo tolerance, and PDF + OCR coverage (via [Text Extractor](https://github.com/scambier/obsidian-text-extractor)). Auto-detected: probed once at startup against `/search?q=` (200 + `application/json` + JSON-array body — unrouted paths return 200 with empty body, so status alone is insufficient); if reachable, the mode appears in the input enum, otherwise it's omitted so the LLM never sees it as an option. Upstream hard-caps results at 50 — the omnisearch branch carries `truncated: true` when that cap was likely hit. Resolves [#51](https://github.com/cyanheads/obsidian-mcp-server/issues/51).
+- **`OBSIDIAN_OMNISEARCH_URL`** — override the derived Omnisearch URL (default: `OBSIDIAN_BASE_URL` host + port `51361`, with `127.0.0.1` mapped to `localhost`). Restart to re-probe.
+- **`obsidian_list_commands` `nameRegex` filter** — optional ECMAScript regex matched against the command display name. Reuses the ReDoS guards from `obsidian_list_tags` (≤256 chars, static rejection of nested-quantifier shapes) via the new shared helper. Response echoes `appliedFilters: { nameRegex }`. Resolves [#53](https://github.com/cyanheads/obsidian-mcp-server/issues/53).
+- **`src/mcp-server/tools/definitions/_shared/regex-safety.ts`** — `nameRegexSafetyIssue(pattern)` + `NAME_REGEX_MAX_LENGTH` lifted out of `obsidian-list-tags.tool.ts` so both filter tools share one implementation. Mirrors the existing `_shared/schemas.ts` pattern.
+- **`ObsidianService.probeOmnisearch(signal?)`** — one-shot 500ms startup probe. Validates status + content-type + array body.
+- **`ObsidianService.searchOmnisearch(ctx, query)`** — normalizes the upstream payload: renames `path` → `filename` (so `PathPolicy.filterReadable` composes), decodes HTML entities + converts `<br>` → `\n` in `excerpt`, drops `vault`. Throws `omnisearch_unreachable` (ServiceUnavailable, retryable) on mid-session failures.
+- **`buildSearchNotesTool({ omnisearchReachable })`** factory replaces the static `obsidianSearchNotes` export — entry point passes the live probe result so the schema reflects what's actually callable. The module still exports a static specimen with `omnisearchReachable: false` for the MCP definition linter and existing tests.
+
+## Changed
+
+- **`obsidian_search_notes` switched from cap+overflow to MCP-spec cursor pagination** (per spec [2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/utils/pagination)) via the framework's `paginateArray` helper. Output now carries `totalCount: number` (post-path-policy, pre-pagination) on every mode and `nextCursor?: string` when a successor page exists. Invalid cursors throw `InvalidParams` per spec. Path-policy denial count stays hidden.
+- **PATCH header rename** — `Apply-If-Content-Preexists` → `Reject-If-Content-Preexists` with sense inversion, tracking [coddingtonbear/obsidian-local-rest-api v4.0.0](https://github.com/coddingtonbear/obsidian-local-rest-api/releases/tag/4.0.0) (markdown-patch 1.0). The public `applyIfContentPreexists` flag stays on the schema for caller stability and `ObsidianService.#buildPatchHeaders` inverts on the way out so the public default (`false`) sends `Reject-If-Content-Preexists: true` and preserves the historical idempotent-by-default behavior. Replace operations are plugin-exempt regardless. **Minimum supported Local REST API: v4.0.0.**
+- **Startup banner** — adds `omnisearchUrl` and `omnisearchReachable` to the structured request context, plus a follow-up info line that reports the resolved URL and which way the mode toggled. The reachability message tells the operator to set `OBSIDIAN_OMNISEARCH_URL` or enable the plugin's HTTP server when the probe fails.
+- **`initObsidianService(config)` moved from `createApp.setup()` to module-load order** in `src/index.ts`. Required because `setup()` runs after tools are passed into `createApp()`, which is too late for the Omnisearch probe to influence `obsidian_search_notes`' mode enum.
+- **`tools/definitions/index.ts`** — `obsidianSearchNotes` no longer included in `readToolDefinitions`; entry point injects `buildSearchNotesTool(...)` directly. `baseToolDefinitions` removed (one stale caller).
+- **`obsidian_list_tags` description** — pointer to discover notes by tag now references `jsonlogic` (`{"in": ["work", {"var": "tags"}]}`) instead of the removed `dataview` mode.
+- **CLAUDE.md** — `tools/definitions/index.ts` description updated for the new factory; `src/` file map mentions `_shared/regex-safety.ts` and the Omnisearch-aware factory.
+- **README** — `obsidian_search_notes` row and dedicated section rewritten for the new mode set, cursor pagination, and Omnisearch caveats. `OBSIDIAN_OMNISEARCH_URL` row added to the env-var table. Prerequisite raised to **Local REST API v4.0.0+**.
+
+## Removed
+
+- **`obsidian_search_notes` `dataview` mode** — DQL support was a thin pass-through to a single Local REST API endpoint that overlaps with `jsonlogic` for the queries agents actually issue (path/date/metadata filters). Removing it tightens the mode enum so the LLM has fewer near-duplicate choices, and frees the slot for `omnisearch`. Use `jsonlogic` for path/frontmatter/stat filtering, or `omnisearch` for ranked relevance.
+- **`ObsidianService.searchDataview(ctx, dql)`** — sole caller removed with the mode. The `application/vnd.olrapi.dataview.dql+txt` content type constant also goes.
+- **`obsidian_search_notes` `excluded` overflow indicator** — replaced by `totalCount` + `nextCursor`. The `EXCLUSION_HINT` constant is removed.
+
+## Fixed
+
+- **`safeCodePoint` (excerpt entity decoder)** — drops a dead `try/catch` around `String.fromCodePoint`; the preceding range guard already covers every `RangeError` condition per spec.
+
+## Migration
+
+| Before | After |
+|:--|:--|
+| `obsidian_search_notes` with `mode: 'dataview'` | Switch to `mode: 'jsonlogic'` (path / frontmatter / stat filters) or `mode: 'omnisearch'` (ranked relevance, when reachable). |
+| Reading `result.excluded.count` | Read `result.totalCount` and check whether `result.nextCursor` is set. |
+| Paging through > 100 hits | Pass `cursor: result.nextCursor` on the next call; the page size is server-determined (50 default, 200 max). |
+| Sending `Apply-If-Content-Preexists` against Local REST API < 4.0.0 | Upgrade the plugin to v4.0.0 or later. The header was renamed upstream; the wire format is incompatible with older builds. |

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -1,6 +1,6 @@
 # obsidian-mcp-server - Directory Structure
 
-Generated on: 2026-05-09 10:34:06
+Generated on: 2026-05-17 21:35:06
 
 ```text
 obsidian-mcp-server/
@@ -117,6 +117,7 @@ obsidian-mcp-server/
 │   │   └── tools/
 │   │       └── definitions/
 │   │           ├── _shared/
+│   │           │   ├── regex-safety.ts
 │   │           │   ├── schemas.ts
 │   │           │   └── suggest-paths.ts
 │   │           ├── index.ts
@@ -171,7 +172,8 @@ obsidian-mcp-server/
 │   │   ├── obsidian-search-notes.test.ts
 │   │   ├── obsidian-write-note.test.ts
 │   │   └── suggest-paths.test.ts
-│   └── helpers.ts
+│   ├── helpers.ts
+│   └── instructions.test.ts
 ├── .dockerignore
 ├── .env.example
 ├── .gitignore

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-mcp-server",
-  "version": "3.1.11",
+  "version": "3.2.0",
   "mcpName": "io.github.cyanheads/obsidian-mcp-server",
   "description": "MCP server for Obsidian vaults — read, write, search, and surgically edit notes, tags, and frontmatter via the Local REST API plugin. STDIO or Streamable HTTP.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/cyanheads/obsidian-mcp-server",
     "source": "github"
   },
-  "version": "3.1.11",
+  "version": "3.2.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "obsidian-mcp-server",
       "runtimeHint": "node",
-      "version": "3.1.11",
+      "version": "3.2.0",
       "packageArguments": [
         {
           "type": "positional",
@@ -95,7 +95,7 @@
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "obsidian-mcp-server",
       "runtimeHint": "node",
-      "version": "3.1.11",
+      "version": "3.2.0",
       "packageArguments": [
         {
           "type": "positional",

--- a/src/config/server-config.ts
+++ b/src/config/server-config.ts
@@ -127,6 +127,13 @@ const ServerConfigSchema = z.object({
     .describe(
       'Global kill switch. When true, denies every write regardless of OBSIDIAN_WRITE_PATHS, and suppresses the OBSIDIAN_ENABLE_COMMANDS pair (commands can mutate). Defaults to false.',
     ),
+  omnisearchUrl: z
+    .string()
+    .url()
+    .optional()
+    .describe(
+      'Override URL for the Omnisearch plugin HTTP server. When unset, derives from OBSIDIAN_BASE_URL host with port 51361 (falling back to http://localhost:51361). Used to enable the optional `omnisearch` mode on `obsidian_search_notes`; if the URL is unreachable at startup, the mode is omitted from the tool schema.',
+    ),
 });
 
 export type ServerConfig = z.infer<typeof ServerConfigSchema>;
@@ -143,6 +150,7 @@ export function getServerConfig(): ServerConfig {
     readPaths: 'OBSIDIAN_READ_PATHS',
     writePaths: 'OBSIDIAN_WRITE_PATHS',
     readOnly: 'OBSIDIAN_READ_ONLY',
+    omnisearchUrl: 'OBSIDIAN_OMNISEARCH_URL',
   });
   return _config;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 /**
  * @fileoverview obsidian-mcp-server entry point. Initializes the Obsidian
- * Local REST API service in `setup()` so handlers can reach it via
- * `getObsidianService()`.
+ * Local REST API service at module load so the Omnisearch probe can run
+ * before tools are constructed — `obsidian_search_notes` is built via a
+ * factory that takes Omnisearch reachability as input, so the `omnisearch`
+ * mode appears in the tool schema only when the plugin is actually reachable.
  * @module index
  */
 
@@ -12,21 +14,34 @@ import { getServerConfig } from '@/config/server-config.js';
 import { allPromptDefinitions } from '@/mcp-server/prompts/definitions/index.js';
 import { allResourceDefinitions } from '@/mcp-server/resources/definitions/index.js';
 import {
+  buildSearchNotesTool,
   commandToolDefinitions,
   readToolDefinitions,
   writeToolDefinitions,
 } from '@/mcp-server/tools/definitions/index.js';
-import { initObsidianService } from '@/services/obsidian/obsidian-service.js';
+import { getObsidianService, initObsidianService } from '@/services/obsidian/obsidian-service.js';
 import { PathPolicy } from '@/services/obsidian/path-policy.js';
 
 const config = getServerConfig();
 const policy = new PathPolicy(config);
 
 /**
+ * Init the service at module load (rather than inside `setup()`) so the
+ * Omnisearch probe can run before tool construction. `setup()` runs after
+ * tools are passed into `createApp()`, which is too late to influence the
+ * search-notes schema.
+ */
+initObsidianService(config);
+const obsidian = getObsidianService();
+const omnisearchReachable = await obsidian.probeOmnisearch();
+
+const searchNotesTool = buildSearchNotesTool({ omnisearchReachable });
+
+/**
  * Build the server-level `instructions` string sent on every `initialize`.
  * Provides baseline orientation about the server and then layers in
  * deployment-specific lines (read-only mode, scoped paths, command-palette
- * toggle) when those flags are active.
+ * toggle, Omnisearch availability) when those flags are active.
  */
 function buildInstructions(): string {
   const sections: string[] = [
@@ -47,6 +62,11 @@ function buildInstructions(): string {
   if (config.enableCommands && !config.readOnly) {
     sections.push(
       'Command-palette tools (`obsidian_list_commands`, `obsidian_execute_command`) are enabled and can fire any Obsidian command. Commands are opaque and may be destructive — prefer dedicated tools when one fits.',
+    );
+  }
+  if (omnisearchReachable) {
+    sections.push(
+      '`obsidian_search_notes` includes an `omnisearch` mode: BM25-ranked, typo-tolerant, with PDF/OCR coverage (via the Text Extractor plugin). Results cap at 50 upstream — narrow the query (quoted phrases, `-exclusion`, `path:` / `ext:` filters) to surface more.',
     );
   }
   return sections.join('\n\n');
@@ -75,16 +95,13 @@ const commandTools =
         }),
       );
 
-const tools = [...readToolDefinitions, ...writeTools, ...commandTools];
+const tools = [...readToolDefinitions, searchNotesTool, ...writeTools, ...commandTools];
 
 const { services } = await createApp({
   tools,
   resources: allResourceDefinitions,
   prompts: allPromptDefinitions,
   instructions: buildInstructions(),
-  setup() {
-    initObsidianService(config);
-  },
 });
 
 /**
@@ -98,8 +115,16 @@ const bannerCtx = requestContextService.createRequestContext({
   operation: 'startup',
   ...policy.describe(),
   enableCommands: config.enableCommands && !config.readOnly,
+  omnisearchUrl: obsidian.omnisearchUrl,
+  omnisearchReachable,
 });
 services.logger.info('Path policy', bannerCtx);
+services.logger.info(
+  omnisearchReachable
+    ? `Omnisearch reachable at ${obsidian.omnisearchUrl} — \`omnisearch\` mode enabled on \`obsidian_search_notes\`.`
+    : `Omnisearch not reachable at ${obsidian.omnisearchUrl} — \`omnisearch\` mode omitted from \`obsidian_search_notes\`. Set OBSIDIAN_OMNISEARCH_URL or enable the Omnisearch plugin's HTTP server to use it.`,
+  bannerCtx,
+);
 if (policy.readOnlyShadowsWritePaths) {
   services.logger.warning(
     'OBSIDIAN_WRITE_PATHS is set but ignored because OBSIDIAN_READ_ONLY=true. Unset one of the two to remove the conflict.',

--- a/src/mcp-server/tools/definitions/_shared/regex-safety.ts
+++ b/src/mcp-server/tools/definitions/_shared/regex-safety.ts
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Static safety guards for user-supplied `nameRegex` filters.
+ * JavaScript's RegExp engine has no native execution timeout, so we statically
+ * reject the textbook catastrophic-backtracking shapes before calling
+ * `new RegExp(...)`. Shared by tools that post-filter upstream listings by
+ * name (`obsidian_list_tags`, `obsidian_list_commands`).
+ * @module mcp-server/tools/definitions/_shared/regex-safety
+ */
+
+/** Maximum allowed pattern length — bounds compile cost and AST surface. */
+export const NAME_REGEX_MAX_LENGTH = 256;
+
+/**
+ * Detects the canonical catastrophic-backtracking shape: a `+`/`*`/`{N,}`
+ * quantifier immediately following a `)` whose interior already ends in a
+ * `+`/`*`/`}` quantifier (e.g. `(a+)+`, `(.*)*`, `(a{2,})*`). Not exhaustive —
+ * patterns with overlapping alternation like `(a|a)*` still slip through —
+ * but eliminates the textbook ReDoS vector at zero runtime cost.
+ */
+const NESTED_QUANTIFIER = /[+*}]\)[*+{]/;
+
+/**
+ * Returns a human-readable reason string when the pattern is unsafe, or
+ * `undefined` when it passes the static guards. Callers compile with
+ * `new RegExp(pattern)` after this returns `undefined` and surface the
+ * returned reason via the tool's `regex_unsafe` error.
+ */
+export function nameRegexSafetyIssue(pattern: string): string | undefined {
+  if (pattern.length > NAME_REGEX_MAX_LENGTH) {
+    return `pattern exceeds ${NAME_REGEX_MAX_LENGTH}-character limit`;
+  }
+  if (NESTED_QUANTIFIER.test(pattern)) {
+    return 'pattern contains nested quantifiers (catastrophic-backtracking risk)';
+  }
+  return;
+}

--- a/src/mcp-server/tools/definitions/_shared/schemas.ts
+++ b/src/mcp-server/tools/definitions/_shared/schemas.ts
@@ -61,7 +61,7 @@ export const PatchOptionsSchema = z
       .boolean()
       .default(false)
       .describe(
-        'Apply the patch even if matching content already exists in the target. Guards against double-applying.',
+        'When false (default), the patch is rejected if the supplied content already appears in the target — idempotent against agent retries. Set to true to force-apply even when it would duplicate. Replace operations are unaffected (the plugin exempts them).',
       ),
     trimTargetWhitespace: z
       .boolean()

--- a/src/mcp-server/tools/definitions/index.ts
+++ b/src/mcp-server/tools/definitions/index.ts
@@ -4,7 +4,9 @@
  * when `OBSIDIAN_READ_ONLY=true`. The command-palette pair is exported
  * separately so the entry point wraps it with `disabledTool()` when either
  * `OBSIDIAN_ENABLE_COMMANDS=false` or `OBSIDIAN_READ_ONLY=true` — keeping this
- * module free of eager config reads.
+ * module free of eager config reads. `obsidian_search_notes` is exposed as a
+ * factory (`buildSearchNotesTool`) because its mode enum is conditional on
+ * Omnisearch reachability, which is only known after the startup probe runs.
  * @module mcp-server/tools/definitions/index
  */
 
@@ -20,15 +22,20 @@ import { obsidianManageTags } from './obsidian-manage-tags.tool.js';
 import { obsidianOpenInUi } from './obsidian-open-in-ui.tool.js';
 import { obsidianPatchNote } from './obsidian-patch-note.tool.js';
 import { obsidianReplaceInNote } from './obsidian-replace-in-note.tool.js';
-import { obsidianSearchNotes } from './obsidian-search-notes.tool.js';
 import { obsidianWriteNote } from './obsidian-write-note.tool.js';
 
-/** Read-only tools — always registered, even with `OBSIDIAN_READ_ONLY=true`. */
+export { buildSearchNotesTool } from './obsidian-search-notes.tool.js';
+
+/**
+ * Read-only tools that don't depend on runtime probes — always registered,
+ * even with `OBSIDIAN_READ_ONLY=true`. `obsidian_search_notes` is constructed
+ * separately in the entry point via `buildSearchNotesTool` so its mode enum
+ * can reflect Omnisearch reachability.
+ */
 export const readToolDefinitions = [
   obsidianGetNote,
   obsidianListNotes,
   obsidianListTags,
-  obsidianSearchNotes,
   obsidianOpenInUi,
 ];
 
@@ -42,9 +49,6 @@ export const writeToolDefinitions = [
   obsidianManageTags,
   obsidianDeleteNote,
 ];
-
-/** Combined base set — preserves the previous registration order. */
-export const baseToolDefinitions = [...readToolDefinitions, ...writeToolDefinitions];
 
 /** Command-palette tools — opt-in via `OBSIDIAN_ENABLE_COMMANDS=true`; suppressed by `OBSIDIAN_READ_ONLY=true`. */
 export const commandToolDefinitions = [obsidianListCommands, obsidianExecuteCommand];

--- a/src/mcp-server/tools/definitions/obsidian-list-commands.tool.ts
+++ b/src/mcp-server/tools/definitions/obsidian-list-commands.tool.ts
@@ -1,17 +1,29 @@
 /**
  * @fileoverview obsidian_list_commands — list Obsidian command-palette commands.
  * Gated behind `OBSIDIAN_ENABLE_COMMANDS=true` alongside `obsidian_execute_command`.
+ * Optional `nameRegex` post-filters the upstream payload before returning, since
+ * vaults with Templater/Dataview/QuickAdd/Excalidraw routinely register 300+
+ * commands and the LLM-bound listing is otherwise mostly noise.
  * @module mcp-server/tools/definitions/obsidian-list-commands.tool
  */
 
 import { tool, z } from '@cyanheads/mcp-ts-core';
+import { JsonRpcErrorCode } from '@cyanheads/mcp-ts-core/errors';
 import { getObsidianService } from '@/services/obsidian/obsidian-service.js';
+import { nameRegexSafetyIssue } from './_shared/regex-safety.js';
 
 export const obsidianListCommands = tool('obsidian_list_commands', {
   description:
-    'List the Obsidian command-palette commands available in the active vault, with their IDs and display names.',
+    'List the Obsidian command-palette commands available in the active vault, with their IDs and display names. Filter to a subset with the optional `nameRegex` matched against the display name.',
   annotations: { readOnlyHint: true, idempotentHint: true },
-  input: z.object({}),
+  input: z.object({
+    nameRegex: z
+      .string()
+      .optional()
+      .describe(
+        'Optional ECMAScript regex (no flags, ≤256 chars, no nested quantifiers like `(a+)+`) matched against the command display name (the field agents search by, not the slug-shaped `id`). Use character classes (`[Tt]emplater`) for case-insensitivity.',
+      ),
+  }),
   output: z.object({
     commands: z
       .array(
@@ -23,20 +35,71 @@ export const obsidianListCommands = tool('obsidian_list_commands', {
           .describe('An Obsidian command-palette entry.'),
       )
       .describe('All commands registered in the active Obsidian instance.'),
+    appliedFilters: z
+      .object({
+        nameRegex: z.string().optional().describe('nameRegex filter applied to this listing.'),
+      })
+      .optional()
+      .describe('Active filters that produced this listing. Absent when no filter was applied.'),
   }),
   auth: ['tool:obsidian_list_commands:read'],
+  errors: [
+    {
+      reason: 'regex_invalid',
+      code: JsonRpcErrorCode.ValidationError,
+      when: 'The supplied `nameRegex` is not a valid ECMAScript regex.',
+      recovery:
+        'Use a valid ECMAScript regex (e.g. `^Templater`), or omit nameRegex to disable filtering.',
+    },
+    {
+      reason: 'regex_unsafe',
+      code: JsonRpcErrorCode.ValidationError,
+      when: 'The supplied `nameRegex` is well-formed but exceeds the 256-character limit or contains nested quantifiers known to cause catastrophic backtracking.',
+      recovery:
+        'Avoid nested quantifiers like `(a+)+` or `(.*)*`. Use a simpler pattern (e.g. `^Templater`), or omit nameRegex to disable filtering.',
+    },
+  ],
 
-  async handler(_input, ctx) {
+  async handler(input, ctx) {
+    let regex: RegExp | undefined;
+    if (input.nameRegex) {
+      const safetyIssue = nameRegexSafetyIssue(input.nameRegex);
+      if (safetyIssue) {
+        throw ctx.fail('regex_unsafe', `Unsafe nameRegex: ${safetyIssue}`, {
+          nameRegex: input.nameRegex,
+          ...ctx.recoveryFor('regex_unsafe'),
+        });
+      }
+      try {
+        regex = new RegExp(input.nameRegex);
+      } catch (err) {
+        throw ctx.fail(
+          'regex_invalid',
+          `Invalid nameRegex: ${(err as Error).message}`,
+          { nameRegex: input.nameRegex, ...ctx.recoveryFor('regex_invalid') },
+          { cause: err },
+        );
+      }
+    }
+
     const svc = getObsidianService();
     const commands = await svc.listCommands(ctx);
-    return { commands };
+    const filtered = regex ? commands.filter((c) => regex.test(c.name)) : commands;
+
+    return {
+      commands: filtered,
+      ...(input.nameRegex ? { appliedFilters: { nameRegex: input.nameRegex } } : {}),
+    };
   },
 
   format: (result) => {
+    const activeRegex = result.appliedFilters?.nameRegex;
     if (result.commands.length === 0) {
-      return [{ type: 'text', text: '_No commands available._' }];
+      const filterNote = activeRegex ? ` matching \`${activeRegex}\`` : '';
+      return [{ type: 'text', text: `_No commands available${filterNote}._` }];
     }
-    const lines = [`**${result.commands.length} commands**`, ''];
+    const filterSuffix = activeRegex ? ` · nameRegex=\`${activeRegex}\`` : '';
+    const lines = [`**${result.commands.length} commands**${filterSuffix}`, ''];
     for (const c of result.commands) lines.push(`- \`${c.id}\` — ${c.name}`);
     return [{ type: 'text', text: lines.join('\n') }];
   },

--- a/src/mcp-server/tools/definitions/obsidian-list-tags.tool.ts
+++ b/src/mcp-server/tools/definitions/obsidian-list-tags.tool.ts
@@ -9,34 +9,11 @@
 import { tool, z } from '@cyanheads/mcp-ts-core';
 import { JsonRpcErrorCode } from '@cyanheads/mcp-ts-core/errors';
 import { getObsidianService } from '@/services/obsidian/obsidian-service.js';
-
-/** Maximum allowed pattern length — bounds compile cost and AST surface. */
-const NAME_REGEX_MAX_LENGTH = 256;
-
-/**
- * Detects the canonical catastrophic-backtracking shape: a `+`/`*`/`{N,}`
- * quantifier immediately following a `)` whose interior already ends in a
- * `+`/`*`/`}` quantifier (e.g. `(a+)+`, `(.*)*`, `(a{2,})*`). Not exhaustive —
- * patterns with overlapping alternation like `(a|a)*` still slip through —
- * but eliminates the textbook ReDoS vector at zero runtime cost. JavaScript's
- * RegExp engine has no native execution timeout, so this static check is the
- * only defense short of running matches in a worker.
- */
-const NESTED_QUANTIFIER = /[+*}]\)[*+{]/;
-
-function nameRegexSafetyIssue(pattern: string): string | undefined {
-  if (pattern.length > NAME_REGEX_MAX_LENGTH) {
-    return `pattern exceeds ${NAME_REGEX_MAX_LENGTH}-character limit`;
-  }
-  if (NESTED_QUANTIFIER.test(pattern)) {
-    return 'pattern contains nested quantifiers (catastrophic-backtracking risk)';
-  }
-  return;
-}
+import { nameRegexSafetyIssue } from './_shared/regex-safety.js';
 
 export const obsidianListTags = tool('obsidian_list_tags', {
   description:
-    'List every tag found across the vault, with usage counts. Includes hierarchical parents — `work/tasks` contributes to both `work` and `work/tasks`. Filter to a subset with the optional `nameRegex`. To find notes by tag, use `obsidian_search_notes` in dataview mode (e.g. `TABLE FROM #work`).',
+    'List every tag found across the vault, with usage counts. Includes hierarchical parents — `work/tasks` contributes to both `work` and `work/tasks`. Filter to a subset with the optional `nameRegex`. To find notes by tag, use `obsidian_search_notes` in jsonlogic mode (e.g. `{"in": ["work", {"var": "tags"}]}`).',
   annotations: { readOnlyHint: true, idempotentHint: true },
   input: z.object({
     nameRegex: z

--- a/src/mcp-server/tools/definitions/obsidian-search-notes.tool.ts
+++ b/src/mcp-server/tools/definitions/obsidian-search-notes.tool.ts
@@ -1,20 +1,31 @@
 /**
- * @fileoverview obsidian_search_notes — text/dataview/jsonlogic search.
- * Caps results at 100 hits and surfaces an `excluded` indicator when more
- * were returned upstream. Text-mode hits are additionally capped per file
- * via `maxMatchesPerHit` so a single match-heavy note can't blow the
- * response budget — clipped hits carry `truncated: true` and `totalMatches`.
+ * @fileoverview obsidian_search_notes — text/jsonlogic/omnisearch search with
+ * MCP-spec cursor pagination. The `omnisearch` mode is added conditionally by
+ * the entry point only when the Omnisearch plugin's HTTP server is reachable
+ * at startup. Text-mode hits additionally clip per file via `maxMatchesPerHit`
+ * so a single match-heavy note can't blow the response budget — clipped hits
+ * carry `truncated: true` and `totalMatches`.
  * @module mcp-server/tools/definitions/obsidian-search-notes.tool
  */
 
-import { tool, z } from '@cyanheads/mcp-ts-core';
+import { type Context, tool, z } from '@cyanheads/mcp-ts-core';
 import { JsonRpcErrorCode } from '@cyanheads/mcp-ts-core/errors';
+import type { RequestContext } from '@cyanheads/mcp-ts-core/utils';
+import { paginateArray } from '@cyanheads/mcp-ts-core/utils';
 import { getObsidianService } from '@/services/obsidian/obsidian-service.js';
 
-const HIT_CAP = 100;
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 200;
 const DEFAULT_MATCHES_PER_HIT = 10;
-const EXCLUSION_HINT =
-  'Narrow your query (add filters or more specific terms) to surface the rest.';
+/** Omnisearch's hardwired upstream cap — pagination/limit params are ignored. */
+const OMNISEARCH_UPSTREAM_CAP = 50;
+
+const CursorSchema = z
+  .string()
+  .optional()
+  .describe(
+    'Opaque cursor from a prior response. Omit for the first page. Page size is server-determined; do not assume a fixed value.',
+  );
 
 const TextHitSchema = z
   .object({
@@ -57,28 +68,61 @@ const StructuredHitSchema = z
   })
   .describe('A file with a structured (Dataview/JSONLogic) result value.');
 
-const ExcludedSchema = z
+const OmnisearchHitSchema = z
   .object({
-    count: z.number().describe('Number of additional hits the upstream returned beyond the cap.'),
-    hint: z.string().describe('Suggestion for narrowing the query.'),
-  })
-  .optional();
-
-export const obsidianSearchNotes = tool('obsidian_search_notes', {
-  description: `Search the vault by text substring, Dataview DQL query, or JSONLogic predicate. Pick the mode that matches the query shape. Results cap at ${HIT_CAP} hits with an \`excluded\` indicator when more were available; text-mode hits also clip per file at \`maxMatchesPerHit\`. On large vaults, narrow with \`pathPrefix\` or lower \`maxMatchesPerHit\` to keep responses compact.`,
-  annotations: { readOnlyHint: true, idempotentHint: true },
-  input: z.object({
-    mode: z
-      .enum(['text', 'dataview', 'jsonlogic'])
+    filename: z.string().describe('Vault-relative path of the matching note.'),
+    basename: z.string().describe('Note basename without extension.'),
+    score: z.number().describe('BM25 relevance score. Higher is more relevant.'),
+    foundWords: z
+      .array(z.string())
       .describe(
-        'Which search algorithm to run. `text` matches a substring case-insensitively across filenames and note bodies, returning surrounding context windows. `dataview` runs a DQL query (e.g. `TABLE WHERE file.mtime > date(today)`) for path/date/metadata filters. `jsonlogic` evaluates a JSONLogic tree against each note, with `var` paths into `path`, `content`, `frontmatter.<key>`, `tags`, and `stat.{ctime,mtime,size}`, plus `glob` and `regexp` operators.',
+        'Query words found in the note. Populated even when no body match exists (e.g. basename-only match), so empty `matches` paired with non-empty `foundWords` is valid.',
+      ),
+    matches: z
+      .array(
+        z
+          .object({
+            match: z.string().describe('The matched substring.'),
+            offset: z.number().describe('Offset of the match within the note body.'),
+          })
+          .describe('A single match span in the note body.'),
+      )
+      .describe('Match positions within the note body. May be empty for basename-only matches.'),
+    excerpt: z
+      .string()
+      .describe(
+        'Surrounding-context excerpt with `<mark>` around matches; HTML entities are decoded and `<br>` becomes `\\n`.',
+      ),
+  })
+  .describe('An Omnisearch BM25-ranked hit.');
+
+/**
+ * Build the `obsidian_search_notes` tool. The `omnisearch` mode is included
+ * in the input/output schemas only when `omnisearchReachable` is true so the
+ * LLM never sees it as an option on a deployment where it can't run. Re-probe
+ * requires a server restart.
+ */
+export function buildSearchNotesTool({ omnisearchReachable }: { omnisearchReachable: boolean }) {
+  const modeEnum = omnisearchReachable
+    ? (['text', 'jsonlogic', 'omnisearch'] as const)
+    : (['text', 'jsonlogic'] as const);
+
+  const description = omnisearchReachable
+    ? 'Search the vault by text substring, JSONLogic predicate, or BM25-ranked Omnisearch query. Pick the mode that matches the query shape — `omnisearch` is best for ranked relevance, typo tolerance, and PDF/OCR coverage (via the Text Extractor plugin). Results paginate via opaque cursors: omit `cursor` for the first page, then pass `nextCursor` from the prior response. Text-mode hits additionally clip per file at `maxMatchesPerHit`.'
+    : 'Search the vault by text substring or JSONLogic predicate. Pick the mode that matches the query shape. Results paginate via opaque cursors: omit `cursor` for the first page, then pass `nextCursor` from the prior response. Text-mode hits additionally clip per file at `maxMatchesPerHit`.';
+
+  const inputSchema = z.object({
+    mode: z
+      .enum(modeEnum)
+      .describe(
+        omnisearchReachable
+          ? 'Which search algorithm to run. `text` matches a substring case-insensitively across filenames and note bodies, returning surrounding context windows. `jsonlogic` evaluates a JSONLogic tree against each note, with `var` paths into `path`, `content`, `frontmatter.<key>`, `tags`, and `stat.{ctime,mtime,size}`, plus `glob` and `regexp` operators. `omnisearch` runs a BM25-ranked query via the Omnisearch plugin — supports quoted phrases, `-exclusion`, `path:` / `ext:` filters, typo tolerance, and PDF/OCR (with Text Extractor); upstream caps results at 50.'
+          : 'Which search algorithm to run. `text` matches a substring case-insensitively across filenames and note bodies, returning surrounding context windows. `jsonlogic` evaluates a JSONLogic tree against each note, with `var` paths into `path`, `content`, `frontmatter.<key>`, `tags`, and `stat.{ctime,mtime,size}`, plus `glob` and `regexp` operators.',
       ),
     query: z
       .string()
       .optional()
-      .describe(
-        'For `text` mode: substring to match. For `dataview` mode: the DQL query string. Required for those modes.',
-      ),
+      .describe('For `text` and `omnisearch` modes: the query string. Required for both.'),
     logic: z
       .record(z.string(), z.unknown())
       .optional()
@@ -101,40 +145,84 @@ export const obsidianSearchNotes = tool('obsidian_search_notes', {
       .describe(
         'Cap on match contexts returned per file in text mode. When clipped, the hit carries `truncated: true` and `totalMatches`.',
       ),
-  }),
-  output: z.object({
+    cursor: CursorSchema,
+  });
+
+  const textBranch = z
+    .object({
+      mode: z.literal('text').describe('Echoed mode.'),
+      hits: z.array(TextHitSchema).describe('Matching files with per-match context.'),
+      totalCount: z
+        .number()
+        .describe('Total post-path-policy hit count across all pages, before pagination.'),
+      nextCursor: z
+        .string()
+        .optional()
+        .describe(
+          'Opaque cursor for the next page. Omitted on the last page (do not treat absent as null).',
+        ),
+    })
+    .describe('Text-search results.');
+
+  const jsonlogicBranch = z
+    .object({
+      mode: z.literal('jsonlogic').describe('Echoed mode.'),
+      hits: z
+        .array(StructuredHitSchema)
+        .describe('Matching files with the JSONLogic result per file.'),
+      totalCount: z
+        .number()
+        .describe('Total post-path-policy hit count across all pages, before pagination.'),
+      nextCursor: z
+        .string()
+        .optional()
+        .describe(
+          'Opaque cursor for the next page. Omitted on the last page (do not treat absent as null).',
+        ),
+    })
+    .describe('JSONLogic results.');
+
+  const omnisearchBranch = z
+    .object({
+      mode: z.literal('omnisearch').describe('Echoed mode.'),
+      hits: z.array(OmnisearchHitSchema).describe('BM25-ranked matching files.'),
+      totalCount: z
+        .number()
+        .describe('Total post-path-policy hit count across all pages, before pagination.'),
+      nextCursor: z
+        .string()
+        .optional()
+        .describe(
+          'Opaque cursor for the next page. Omitted on the last page (do not treat absent as null).',
+        ),
+      truncated: z
+        .boolean()
+        .describe(
+          "True when the upstream returned exactly 50 raw hits (Omnisearch's hardwired cap); more matches may exist that are not retrievable. Narrow the query to surface additional results.",
+        ),
+    })
+    .describe('Omnisearch BM25 results.');
+
+  const branches = omnisearchReachable
+    ? ([textBranch, jsonlogicBranch, omnisearchBranch] as const)
+    : ([textBranch, jsonlogicBranch] as const);
+
+  const outputSchema = z.object({
     result: z
-      .discriminatedUnion('mode', [
-        z
-          .object({
-            mode: z.literal('text').describe('Echoed mode.'),
-            hits: z.array(TextHitSchema).describe('Matching files with per-match context.'),
-            excluded: ExcludedSchema.describe('Present when results were truncated to the cap.'),
-          })
-          .describe('Text-search results.'),
-        z
-          .object({
-            mode: z.literal('dataview').describe('Echoed mode.'),
-            hits: z
-              .array(StructuredHitSchema)
-              .describe('Matching files with the query result per file.'),
-            excluded: ExcludedSchema.describe('Present when results were truncated to the cap.'),
-          })
-          .describe('Dataview DQL results.'),
-        z
-          .object({
-            mode: z.literal('jsonlogic').describe('Echoed mode.'),
-            hits: z
-              .array(StructuredHitSchema)
-              .describe('Matching files with the JSONLogic result per file.'),
-            excluded: ExcludedSchema.describe('Present when results were truncated to the cap.'),
-          })
-          .describe('JSONLogic results.'),
-      ])
+      .discriminatedUnion('mode', [...branches])
       .describe('Mode-discriminated search payload.'),
-  }),
-  auth: ['tool:obsidian_search_notes:read'],
-  errors: [
+  });
+
+  /**
+   * Declared inline as a `const` tuple so `tool()`'s `const TErrors` generic
+   * captures the literal reason strings — that's what gives the handler its
+   * typed `ctx.fail<'reason'>(...)`. The `omnisearch_unreachable` entry is
+   * declared unconditionally even when `omnisearchReachable` is false; the
+   * branch that throws it only runs in the omnisearch handler path (which
+   * only runs when reachable), so the entry is harmless when unused and
+   * keeps the contract shape stable across deployments.
+   */
+  const errors = [
     {
       reason: 'path_prefix_invalid_mode',
       code: JsonRpcErrorCode.ValidationError,
@@ -144,9 +232,9 @@ export const obsidianSearchNotes = tool('obsidian_search_notes', {
     {
       reason: 'query_required',
       code: JsonRpcErrorCode.ValidationError,
-      when: '`query` is missing for `text` or `dataview` mode (required for both).',
+      when: '`query` is missing for `text` or `omnisearch` mode (required for both).',
       recovery:
-        'Pass `query` — search terms for text mode (e.g. "TODO"), or DQL like "TABLE WHERE file.mtime > date(today)" for dataview mode.',
+        'Pass `query` — substring for text mode, or BM25 query syntax (quoted phrases, `-exclusion`, `path:` / `ext:` filters) for omnisearch.',
     },
     {
       reason: 'logic_required',
@@ -155,112 +243,177 @@ export const obsidianSearchNotes = tool('obsidian_search_notes', {
       recovery:
         'Pass a JSONLogic tree as `logic`, e.g. `{"glob": [{"var": "path"}, "Projects/*.md"]}`.',
     },
-  ],
+    {
+      reason: 'omnisearch_unreachable',
+      code: JsonRpcErrorCode.ServiceUnavailable,
+      when: 'Omnisearch was reachable at startup but is now unreachable (Obsidian quit, plugin disabled, or mobile session).',
+      retryable: true,
+      recovery:
+        'Restart Obsidian with the Omnisearch plugin enabled, then restart this MCP server so it re-probes the plugin URL.',
+    },
+  ] as const;
 
-  async handler(input, ctx) {
-    const svc = getObsidianService();
+  return tool('obsidian_search_notes', {
+    description,
+    annotations: { readOnlyHint: true, idempotentHint: true },
+    input: inputSchema,
+    output: outputSchema,
+    auth: ['tool:obsidian_search_notes:read'],
+    errors,
 
-    if (input.pathPrefix && input.mode !== 'text') {
-      throw ctx.fail('path_prefix_invalid_mode', '`pathPrefix` is only valid in text mode.', {
-        mode: input.mode,
-        ...ctx.recoveryFor('path_prefix_invalid_mode'),
-      });
-    }
+    async handler(input, ctx) {
+      const svc = getObsidianService();
 
-    /**
-     * Path-policy post-filter: reads outside OBSIDIAN_READ_PATHS are dropped
-     * silently, before the per-mode cap. The `excluded` overflow indicator
-     * counts hits trimmed by the cap, not hits dropped by the policy — leaking
-     * the dropped count would defeat the gate.
-     */
-    const policy = svc.policy;
+      if (input.pathPrefix && input.mode !== 'text') {
+        throw ctx.fail('path_prefix_invalid_mode', '`pathPrefix` is only valid in text mode.', {
+          mode: input.mode,
+          ...ctx.recoveryFor('path_prefix_invalid_mode'),
+        });
+      }
 
-    if (input.mode === 'text') {
+      const policy = svc.policy;
+
+      if (input.mode === 'text') {
+        if (!input.query) {
+          throw ctx.fail('query_required', '`query` is required for text mode.', {
+            mode: input.mode,
+            ...ctx.recoveryFor('query_required'),
+          });
+        }
+        const raw = await svc.searchText(ctx, input.query, input.contextLength);
+        const prefix = input.pathPrefix;
+        const prefixed = prefix ? raw.filter((h) => h.filename.startsWith(prefix)) : raw;
+        const allowed = policy.filterReadable(prefixed);
+        const clipped = allowed.map((h) => clipMatches(h, input.maxMatchesPerHit));
+        return { result: { mode: 'text' as const, ...paginate(clipped, input.cursor, ctx) } };
+      }
+
+      if (input.mode === 'jsonlogic') {
+        if (!input.logic) {
+          throw ctx.fail(
+            'logic_required',
+            '`logic` (JSONLogic tree) is required for jsonlogic mode.',
+            { mode: input.mode, ...ctx.recoveryFor('logic_required') },
+          );
+        }
+        const raw = await svc.searchJsonLogic(ctx, input.logic);
+        const allowed = policy.filterReadable(raw);
+        return { result: { mode: 'jsonlogic' as const, ...paginate(allowed, input.cursor, ctx) } };
+      }
+
+      // omnisearch — only reachable when omnisearchReachable is true at build time.
       if (!input.query) {
-        throw ctx.fail('query_required', '`query` is required for text mode.', {
+        throw ctx.fail('query_required', '`query` is required for omnisearch mode.', {
           mode: input.mode,
           ...ctx.recoveryFor('query_required'),
         });
       }
-      const all = await svc.searchText(ctx, input.query, input.contextLength);
-      const prefix = input.pathPrefix;
-      const prefixed = prefix ? all.filter((h) => h.filename.startsWith(prefix)) : all;
-      const allowed = policy.filterReadable(prefixed);
-      const matchCap = input.maxMatchesPerHit;
-      const clipped = allowed.map((h) => clipMatches(h, matchCap));
-      const capped = applyCap(clipped);
-      return { result: { mode: 'text' as const, ...capped } };
-    }
+      const raw = await svc.searchOmnisearch(ctx, input.query);
+      /**
+       * Compute `truncated` against the raw upstream array, before path-policy
+       * filtering — a filtered-down set legitimately under 50 should not be
+       * reported as truncated.
+       */
+      const truncated = raw.length >= OMNISEARCH_UPSTREAM_CAP;
+      const allowed = policy.filterReadable(raw);
+      return {
+        result: {
+          mode: 'omnisearch' as const,
+          ...paginate(allowed, input.cursor, ctx),
+          truncated,
+        },
+      };
+    },
 
-    if (input.mode === 'dataview') {
-      if (!input.query) {
-        throw ctx.fail('query_required', '`query` (DQL string) is required for dataview mode.', {
-          mode: input.mode,
-          ...ctx.recoveryFor('query_required'),
-        });
+    format: ({ result }) => {
+      const lines: string[] = [];
+      const pageInfo = `${result.hits.length} on this page · ${result.totalCount} total`;
+      const cursorInfo = result.nextCursor ? ' · more available' : '';
+      lines.push(`**Search (${result.mode}) — ${pageInfo}${cursorInfo}**`);
+      if (result.mode === 'omnisearch' && result.truncated) {
+        lines.push(
+          `_Upstream returned the full ${OMNISEARCH_UPSTREAM_CAP}-hit cap; more matches may exist. Narrow the query to surface them._`,
+        );
       }
-      const all = await svc.searchDataview(ctx, input.query);
-      const allowed = policy.filterReadable(all);
-      const capped = applyCap(allowed);
-      return { result: { mode: 'dataview' as const, ...capped } };
-    }
-
-    if (!input.logic) {
-      throw ctx.fail('logic_required', '`logic` (JSONLogic tree) is required for jsonlogic mode.', {
-        mode: input.mode,
-        ...ctx.recoveryFor('logic_required'),
-      });
-    }
-    const all = await svc.searchJsonLogic(ctx, input.logic);
-    const allowed = policy.filterReadable(all);
-    const capped = applyCap(allowed);
-    return { result: { mode: 'jsonlogic' as const, ...capped } };
-  },
-
-  format: ({ result }) => {
-    const lines: string[] = [`**Search (${result.mode}) — ${result.hits.length} hits**`];
-    if (result.excluded) {
-      lines.push(`_Excluded ${result.excluded.count} additional hits — ${result.excluded.hint}_`);
-    }
-    if (result.hits.length === 0) {
-      lines.push(
-        '',
-        '_No matches. Try broader terms, a different mode, or check that the path/filter is correct._',
-      );
-      return [{ type: 'text', text: lines.join('\n') }];
-    }
-    lines.push('');
-    if (result.mode === 'text') {
-      for (const h of result.hits) {
-        const score = h.score !== undefined ? ` (score: ${h.score})` : '';
-        const trunc = h.truncated
-          ? ` — truncated, showing first ${h.matches.length} of ${h.totalMatches} matches`
-          : '';
-        lines.push(`### ${h.filename}${score}${trunc}`);
-        for (const m of h.matches) {
-          lines.push(`- match[${m.match.start}–${m.match.end}]: ${truncate(m.context, 240)}`);
+      if (result.nextCursor) {
+        lines.push(`_Next page cursor: \`${result.nextCursor}\`_`);
+      }
+      if (result.hits.length === 0) {
+        lines.push(
+          '',
+          '_No matches. Try broader terms, a different mode, or check that the path/filter is correct._',
+        );
+        return [{ type: 'text', text: lines.join('\n') }];
+      }
+      lines.push('');
+      if (result.mode === 'text') {
+        for (const h of result.hits) {
+          const score = h.score !== undefined ? ` (score: ${h.score})` : '';
+          const trunc = h.truncated
+            ? ` — truncated, showing first ${h.matches.length} of ${h.totalMatches} matches`
+            : '';
+          lines.push(`### ${h.filename}${score}${trunc}`);
+          for (const m of h.matches) {
+            lines.push(`- match[${m.match.start}–${m.match.end}]: ${truncate(m.context, 240)}`);
+          }
+        }
+      } else if (result.mode === 'omnisearch') {
+        for (const h of result.hits) {
+          lines.push(`### ${h.filename} (score: ${h.score.toFixed(2)})`);
+          if (h.foundWords.length > 0) {
+            lines.push(`**Matched:** ${h.foundWords.map((w) => `\`${w}\``).join(', ')}`);
+          }
+          if (h.excerpt) lines.push(`> ${h.excerpt.replace(/\n/g, '\n> ')}`);
+        }
+      } else {
+        for (const h of result.hits) {
+          lines.push(`### ${h.filename}`);
+          lines.push('```json');
+          lines.push(safeJsonStringify(h.result));
+          lines.push('```');
         }
       }
-    } else {
-      for (const h of result.hits) {
-        lines.push(`### ${h.filename}`);
-        lines.push('```json');
-        lines.push(safeJsonStringify(h.result));
-        lines.push('```');
-      }
-    }
-    return [{ type: 'text', text: lines.join('\n') }];
-  },
-});
+      return [{ type: 'text', text: lines.join('\n') }];
+    },
+  });
+}
 
-function applyCap<T>(all: T[]): {
-  hits: T[];
-  excluded: { count: number; hint: string } | undefined;
-} {
-  if (all.length <= HIT_CAP) return { hits: all, excluded: undefined };
+/**
+ * Static specimen for the MCP definition linter (which duck-types tool
+ * exports out of each `.tool.ts` file) and for existing tests that import
+ * the tool directly. Defaults to `omnisearchReachable: false` — the safe
+ * baseline that doesn't assume the optional plugin is installed. The entry
+ * point (`src/index.ts`) builds the live tool via `buildSearchNotesTool`
+ * with the actual probe result; this export is not the registered tool.
+ * The omnisearch-enabled variant is exercised by tests rather than the
+ * linter (two exports under the same tool name would collide on
+ * `name-unique`).
+ */
+export const obsidianSearchNotes = buildSearchNotesTool({ omnisearchReachable: false });
+
+/**
+ * Apply MCP-spec cursor pagination to a fully assembled, post-filter result
+ * array. Returns the page's hits, the total pre-pagination count, and
+ * `nextCursor` (omitted on the last page). Localizes the `Context` →
+ * `RequestContext` cast — `paginateArray`'s signature requires the index-
+ * signature shape that handler-facing `Context` doesn't carry.
+ */
+function paginate<T>(
+  items: T[],
+  cursor: string | undefined,
+  ctx: Context,
+): { hits: T[]; totalCount: number; nextCursor?: string } {
+  const page = paginateArray(
+    items,
+    cursor,
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    ctx as unknown as RequestContext,
+  );
   return {
-    hits: all.slice(0, HIT_CAP),
-    excluded: { count: all.length - HIT_CAP, hint: EXCLUSION_HINT },
+    hits: page.items,
+    totalCount: page.totalCount ?? items.length,
+    ...(page.nextCursor !== undefined ? { nextCursor: page.nextCursor } : {}),
   };
 }
 

--- a/src/services/obsidian/obsidian-service.ts
+++ b/src/services/obsidian/obsidian-service.ts
@@ -6,7 +6,13 @@
  */
 
 import type { Context } from '@cyanheads/mcp-ts-core';
-import { forbidden, notFound, unauthorized, validationError } from '@cyanheads/mcp-ts-core/errors';
+import {
+  forbidden,
+  notFound,
+  serviceUnavailable,
+  unauthorized,
+  validationError,
+} from '@cyanheads/mcp-ts-core/errors';
 import { httpErrorFromResponse, withRetry } from '@cyanheads/mcp-ts-core/utils';
 import { Agent, type Dispatcher, type RequestInit, fetch as undiciFetch } from 'undici';
 import { getServerConfig, type ServerConfig } from '@/config/server-config.js';
@@ -18,6 +24,7 @@ import type {
   NoteTarget,
   ObsidianCommand,
   ObsidianTag,
+  OmnisearchHit,
   PatchHeaders,
   StructuredSearchHit,
   TextSearchHit,
@@ -68,9 +75,28 @@ interface RawStructuredSearchHit {
   result: unknown;
 }
 
+/**
+ * Upstream Omnisearch payload. The plugin returns one of these per file; we
+ * rename `path` to `filename` on the way out so `PathPolicy.filterReadable`
+ * can match the shape, and drop `vault` since this server is single-vault.
+ */
+interface RawOmnisearchHit {
+  basename: string;
+  excerpt: string;
+  foundWords: string[];
+  matches: Array<{ match: string; offset: number }>;
+  path: string;
+  score: number;
+  vault?: string;
+}
+
+/** Per-call timeout for the startup probe — covers the 4-tuple TCP handshake + a tiny GET. */
+const OMNISEARCH_PROBE_TIMEOUT_MS = 500;
+
+const OMNISEARCH_DEFAULT_PORT = '51361';
+
 const NOTE_JSON_ACCEPT = 'application/vnd.olrapi.note+json';
 const DOCUMENT_MAP_ACCEPT = 'application/vnd.olrapi.document-map+json';
-const DATAVIEW_DQL_CT = 'application/vnd.olrapi.dataview.dql+txt';
 const JSONLOGIC_CT = 'application/vnd.olrapi.jsonlogic+json';
 
 /**
@@ -85,6 +111,7 @@ export class ObsidianService {
   readonly #dispatcher: Dispatcher;
   readonly #fetch: ObsidianFetch;
   readonly #policy: PathPolicy;
+  readonly #omnisearchUrl: string;
 
   /**
    * @param config - Validated server config (api key, base URL, TLS, timeouts).
@@ -94,6 +121,7 @@ export class ObsidianService {
   constructor(config: ServerConfig, fetchImpl?: ObsidianFetch) {
     this.#config = config;
     this.#policy = new PathPolicy(config);
+    this.#omnisearchUrl = deriveOmnisearchUrl(config);
     /**
      * Bun's runtime ignores undici's per-dispatcher `connect.rejectUnauthorized`
      * option, so the only reliable opt-out under Bun is the process-wide
@@ -116,6 +144,11 @@ export class ObsidianService {
   /** Path-policy accessor — used by `obsidian_search_notes` to filter hits. */
   get policy(): PathPolicy {
     return this.#policy;
+  }
+
+  /** Resolved Omnisearch URL (derived from baseUrl or OBSIDIAN_OMNISEARCH_URL override). */
+  get omnisearchUrl(): string {
+    return this.#omnisearchUrl;
   }
 
   // ── Status ───────────────────────────────────────────────────────────────
@@ -361,15 +394,6 @@ export class ObsidianService {
     return (await res.json()) as RawSimpleSearchHit[];
   }
 
-  async searchDataview(ctx: Context, dql: string): Promise<StructuredSearchHit[]> {
-    const res = await this.#request(ctx, '/search/', {
-      method: 'POST',
-      headers: { 'Content-Type': DATAVIEW_DQL_CT },
-      body: dql,
-    });
-    return (await res.json()) as RawStructuredSearchHit[];
-  }
-
   async searchJsonLogic(
     ctx: Context,
     logic: Record<string, unknown>,
@@ -380,6 +404,77 @@ export class ObsidianService {
       body: JSON.stringify(logic),
     });
     return (await res.json()) as RawStructuredSearchHit[];
+  }
+
+  /**
+   * One-shot startup probe for the Omnisearch plugin's HTTP endpoint. Returns
+   * `true` only when the response is `HTTP 200`, declares `application/json`,
+   * and the body parses as a JSON array — unrouted paths on the Omnisearch
+   * server also return `200` with an empty body, so status alone is
+   * insufficient. The entry point passes the return value into the
+   * `obsidian_search_notes` factory to decide whether to expose the
+   * `omnisearch` mode.
+   */
+  async probeOmnisearch(signal?: AbortSignal): Promise<boolean> {
+    const probeSignal = signal ?? AbortSignal.timeout(OMNISEARCH_PROBE_TIMEOUT_MS);
+    try {
+      const res = await this.#fetch(`${this.#omnisearchUrl}/search?q=`, {
+        method: 'GET',
+        dispatcher: this.#dispatcher,
+        signal: probeSignal,
+      });
+      if (!res.ok) return false;
+      const contentType = res.headers.get('content-type') ?? '';
+      if (!contentType.toLowerCase().includes('application/json')) return false;
+      const body = await res.json().catch(() => undefined);
+      return Array.isArray(body);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Query the Omnisearch HTTP endpoint. Normalizes the response on the way
+   * out: decodes HTML entities + `<br>` → `\n` in `excerpt`, renames `path`
+   * to `filename`, and drops `vault`. Throws `omnisearch_unreachable`
+   * (ServiceUnavailable) on network failures or non-2xx responses — the
+   * plugin can shut down mid-session (Obsidian quits, plugin disabled), and
+   * the tool needs a distinct signal from the upstream's success cases.
+   */
+  async searchOmnisearch(ctx: Context, query: string): Promise<OmnisearchHit[]> {
+    const url = `${this.#omnisearchUrl}/search?q=${encodeURIComponent(query)}`;
+    let res: UndiciResponse;
+    try {
+      res = await this.#fetch(url, {
+        method: 'GET',
+        dispatcher: this.#dispatcher,
+        signal: ctx.signal,
+      });
+    } catch (err) {
+      if (ctx.signal?.aborted) throw err;
+      throw serviceUnavailable(
+        `Omnisearch unreachable at ${this.#omnisearchUrl}. The plugin may have stopped (Obsidian quit, plugin disabled, or mobile session).`,
+        {
+          reason: 'omnisearch_unreachable',
+          url: this.#omnisearchUrl,
+          ...ctx.recoveryFor('omnisearch_unreachable'),
+        },
+        { cause: err },
+      );
+    }
+    if (!res.ok) {
+      throw serviceUnavailable(
+        `Omnisearch returned HTTP ${res.status} at ${this.#omnisearchUrl}.`,
+        {
+          reason: 'omnisearch_unreachable',
+          url: this.#omnisearchUrl,
+          status: res.status,
+          ...ctx.recoveryFor('omnisearch_unreachable'),
+        },
+      );
+    }
+    const body = (await res.json()) as RawOmnisearchHit[];
+    return body.map(normalizeOmnisearchHit);
   }
 
   // ── UI / commands ────────────────────────────────────────────────────────
@@ -470,7 +565,17 @@ export class ObsidianService {
     };
     if (p.targetDelimiter) headers['Target-Delimiter'] = p.targetDelimiter;
     if (p.createTargetIfMissing) headers['Create-Target-If-Missing'] = 'true';
-    if (p.applyIfContentPreexists) headers['Apply-If-Content-Preexists'] = 'true';
+    /**
+     * Sense inversion: markdown-patch 1.0 (shipped with Local REST API v4.0.0)
+     * renamed `Apply-If-Content-Preexists` to `Reject-If-Content-Preexists`
+     * and flipped the default — patches now apply regardless of duplicates
+     * unless the caller opts into rejection. We keep `applyIfContentPreexists`
+     * on the public schema for caller stability and translate here: a falsy
+     * value (the public default) sends the new Reject header to preserve the
+     * historical idempotent-by-default behavior. Replace operations are
+     * exempt at the plugin layer regardless of this flag.
+     */
+    if (!p.applyIfContentPreexists) headers['Reject-If-Content-Preexists'] = 'true';
     if (p.trimTargetWhitespace) headers['Trim-Target-Whitespace'] = 'true';
     return headers;
   }
@@ -717,6 +822,61 @@ function parseContentLength(res: UndiciResponse, url: string): number {
     throw new Error(`Obsidian Local REST API returned invalid Content-Length '${raw}' for ${url}.`);
   }
   return n;
+}
+
+/**
+ * Resolve the Omnisearch URL. Override wins. Otherwise: take the host from
+ * `OBSIDIAN_BASE_URL`, force `http:` (Omnisearch is HTTP-only), swap port
+ * `27123/27124` → `51361`. `127.0.0.1` is mapped to `localhost` since
+ * Omnisearch's current Node listener binds IPv4 only but the platform's
+ * loopback resolver is flexible — `localhost` insulates us if a future
+ * build switches binding. Falls back to `http://localhost:51361` on any
+ * URL parse failure (config validation catches malformed `baseUrl`, so this
+ * is belt-and-suspenders).
+ */
+function deriveOmnisearchUrl(config: ServerConfig): string {
+  if (config.omnisearchUrl) return config.omnisearchUrl.replace(/\/+$/, '');
+  try {
+    const u = new URL(config.baseUrl);
+    const host = u.hostname === '127.0.0.1' ? 'localhost' : u.hostname;
+    return `http://${host}:${OMNISEARCH_DEFAULT_PORT}`;
+  } catch {
+    return `http://localhost:${OMNISEARCH_DEFAULT_PORT}`;
+  }
+}
+
+function normalizeOmnisearchHit(raw: RawOmnisearchHit): OmnisearchHit {
+  return {
+    basename: raw.basename,
+    excerpt: cleanExcerpt(raw.excerpt),
+    filename: raw.path,
+    foundWords: raw.foundWords,
+    matches: raw.matches,
+    score: raw.score,
+  };
+}
+
+/**
+ * Normalize Omnisearch's excerpt HTML: `<br>` → `\n`, decode the entities
+ * the upstream actually emits (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&#039;`,
+ * `&apos;`, plus numeric `&#NNN;` / `&#xNN;`). `<mark>` tags are preserved —
+ * they highlight the match span and are interpretable as emphasis.
+ */
+function cleanExcerpt(excerpt: string): string {
+  return excerpt
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => safeCodePoint(parseInt(n, 16)))
+    .replace(/&#(\d+);/g, (_, n) => safeCodePoint(Number(n)))
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
+function safeCodePoint(cp: number): string {
+  if (!Number.isInteger(cp) || cp < 0 || cp > 0x10ffff) return '';
+  return String.fromCodePoint(cp);
 }
 
 function parseJsonObject(text: string): UpstreamErrorBody | undefined {

--- a/src/services/obsidian/types.ts
+++ b/src/services/obsidian/types.ts
@@ -61,7 +61,7 @@ export interface ObsidianCommand {
   name: string;
 }
 
-export type SearchMode = 'text' | 'dataview' | 'jsonlogic';
+export type SearchMode = 'text' | 'jsonlogic' | 'omnisearch';
 
 export interface TextSearchHit {
   filename: string;
@@ -77,7 +77,29 @@ export interface StructuredSearchHit {
   result: unknown;
 }
 
+/**
+ * Normalized Omnisearch hit. The upstream `path` is renamed to `filename` so
+ * the shape composes with `PathPolicy.filterReadable`. `excerpt` has had its
+ * HTML entities decoded and `<br>` tags converted to newlines. `vault` is
+ * dropped — this server is single-vault.
+ */
+export interface OmnisearchHit {
+  basename: string;
+  excerpt: string;
+  filename: string;
+  foundWords: string[];
+  matches: Array<{ match: string; offset: number }>;
+  score: number;
+}
+
 export interface PatchHeaders {
+  /**
+   * When false/undefined (the protective default), the patch is rejected if
+   * matching content already exists in the target. Set to true to force-apply
+   * even when it would duplicate. The wire header is `Reject-If-Content-
+   * Preexists` (markdown-patch 1.0+) — the service inverts this flag on the
+   * way out. Replace operations are exempt at the plugin layer.
+   */
   applyIfContentPreexists?: boolean | undefined;
   contentType?: 'markdown' | 'json' | undefined;
   createTargetIfMissing?: boolean | undefined;

--- a/tests/services/obsidian-service.test.ts
+++ b/tests/services/obsidian-service.test.ts
@@ -154,16 +154,17 @@ describe('ObsidianService.patchNote header building', () => {
     expect(seenHeaders['create-target-if-missing'] ?? seenHeaders['Create-Target-If-Missing']).toBe(
       'true',
     );
+    // applyIfContentPreexists: true → no Reject header (force-apply, even if duplicate).
     expect(
-      seenHeaders['apply-if-content-preexists'] ?? seenHeaders['Apply-If-Content-Preexists'],
-    ).toBe('true');
+      seenHeaders['reject-if-content-preexists'] ?? seenHeaders['Reject-If-Content-Preexists'],
+    ).toBeUndefined();
     expect(seenHeaders['trim-target-whitespace'] ?? seenHeaders['Trim-Target-Whitespace']).toBe(
       'true',
     );
     expect(seenHeaders['content-type'] ?? seenHeaders['Content-Type']).toBe('text/markdown');
   });
 
-  it('omits unset option headers when the corresponding flag is undefined', async () => {
+  it('sends Reject-If-Content-Preexists by default to preserve idempotency under retries', async () => {
     let seenHeaders: Record<string, string> = {};
     pool.intercept({ path: '/vault/N.md', method: 'PATCH' }).reply((opts) => {
       seenHeaders = (opts.headers as Record<string, string>) ?? {};
@@ -178,9 +179,13 @@ describe('ObsidianService.patchNote header building', () => {
     });
 
     expect(seenHeaders['create-target-if-missing']).toBeUndefined();
-    expect(seenHeaders['apply-if-content-preexists']).toBeUndefined();
     expect(seenHeaders['trim-target-whitespace']).toBeUndefined();
     expect(seenHeaders['content-type'] ?? seenHeaders['Content-Type']).toBe('application/json');
+    // Protective default — preserves the historical idempotent-by-default behavior
+    // under the renamed/inverted markdown-patch 1.0 flag.
+    expect(
+      seenHeaders['reject-if-content-preexists'] ?? seenHeaders['Reject-If-Content-Preexists'],
+    ).toBe('true');
   });
 });
 
@@ -351,18 +356,6 @@ describe('ObsidianService search', () => {
     await service.searchText(ctx, 'hello world', 50);
     expect(seenPath).toContain('query=hello+world');
     expect(seenPath).toContain('contextLength=50');
-  });
-
-  it('dataview search uses the DQL content type', async () => {
-    let seenContentType = '';
-    pool.intercept({ path: '/search/', method: 'POST' }).reply((opts) => {
-      const headers = opts.headers as Record<string, string>;
-      seenContentType = headers['content-type'] ?? headers['Content-Type'] ?? '';
-      return { statusCode: 200, data: [{ filename: 'x.md', result: [] }] };
-    });
-
-    await service.searchDataview(ctx, 'TABLE file.mtime FROM ""');
-    expect(seenContentType).toBe('application/vnd.olrapi.dataview.dql+txt');
   });
 
   it('jsonlogic search uses the JSONLogic content type and JSON-stringifies the body', async () => {

--- a/tests/tools/obsidian-list-commands.test.ts
+++ b/tests/tools/obsidian-list-commands.test.ts
@@ -3,6 +3,7 @@
  * @module tests/tools/obsidian-list-commands.test
  */
 
+import { JsonRpcErrorCode } from '@cyanheads/mcp-ts-core/errors';
 import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
 import { describe, expect, it } from 'vitest';
 import { obsidianListCommands } from '@/mcp-server/tools/definitions/obsidian-list-commands.tool.js';
@@ -34,7 +35,99 @@ describe('obsidian_list_commands', () => {
       { id: 'editor:save-file', name: 'Save current file' },
       { id: 'workspace:close-tab', name: 'Close tab' },
     ]);
+    expect(out.appliedFilters).toBeUndefined();
   });
+
+  it('applies nameRegex to keep only matching commands by display name', async () => {
+    harness
+      .current()
+      .pool.intercept({ path: '/commands/', method: 'GET' })
+      .reply(
+        200,
+        {
+          commands: [
+            {
+              id: 'templater-obsidian:new-template',
+              name: 'Templater: Create new note from template',
+            },
+            {
+              id: 'templater-obsidian:insert-template',
+              name: 'Templater: Open insert template modal',
+            },
+            { id: 'editor:save-file', name: 'Save current file' },
+          ],
+        },
+        { headers: { 'content-type': 'application/json' } },
+      );
+
+    const out = await obsidianListCommands.handler(
+      obsidianListCommands.input.parse({ nameRegex: '^Templater' }),
+      createMockContext(),
+    );
+    expect(out.commands).toEqual([
+      { id: 'templater-obsidian:new-template', name: 'Templater: Create new note from template' },
+      { id: 'templater-obsidian:insert-template', name: 'Templater: Open insert template modal' },
+    ]);
+    expect(out.appliedFilters).toEqual({ nameRegex: '^Templater' });
+  });
+
+  it('returns an empty list with appliedFilters echoed when nameRegex excludes everything', async () => {
+    harness
+      .current()
+      .pool.intercept({ path: '/commands/', method: 'GET' })
+      .reply(
+        200,
+        { commands: [{ id: 'editor:save-file', name: 'Save current file' }] },
+        { headers: { 'content-type': 'application/json' } },
+      );
+
+    const out = await obsidianListCommands.handler(
+      obsidianListCommands.input.parse({ nameRegex: '^nothing-matches$' }),
+      createMockContext(),
+    );
+    expect(out.commands).toEqual([]);
+    expect(out.appliedFilters).toEqual({ nameRegex: '^nothing-matches$' });
+  });
+
+  it('throws regex_invalid (ValidationError) when nameRegex is not valid', async () => {
+    await expect(
+      obsidianListCommands.handler(
+        obsidianListCommands.input.parse({ nameRegex: '[' }),
+        createMockContext({ errors: obsidianListCommands.errors }),
+      ),
+    ).rejects.toMatchObject({
+      code: JsonRpcErrorCode.ValidationError,
+      data: { reason: 'regex_invalid' },
+    });
+  });
+
+  /**
+   * Regression: see obsidian-list-tags.test.ts for the full rationale.
+   * Catastrophic-backtracking patterns must be rejected statically or
+   * the request stalls the server.
+   */
+  it('does not hang on a ReDoS pattern (rejects unsafe regex or completes within 1s)', async () => {
+    const longA = 'a'.repeat(28);
+    harness
+      .current()
+      .pool.intercept({ path: '/commands/', method: 'GET' })
+      .reply(
+        200,
+        { commands: [{ id: 'x:y', name: `${longA}b` }] },
+        { headers: { 'content-type': 'application/json' } },
+      );
+
+    const start = Date.now();
+    try {
+      await obsidianListCommands.handler(
+        obsidianListCommands.input.parse({ nameRegex: '^(a+)+$' }),
+        createMockContext({ errors: obsidianListCommands.errors }),
+      );
+    } catch (err) {
+      expect(err).toMatchObject({ code: expect.any(Number) });
+    }
+    expect(Date.now() - start).toBeLessThan(1_000);
+  }, 10_000);
 });
 
 describe('obsidian_list_commands / format()', () => {
@@ -45,5 +138,25 @@ describe('obsidian_list_commands / format()', () => {
     const text = (blocks[0] as { text: string }).text;
     expect(text).toContain('a:b');
     expect(text).toContain('A B');
+  });
+
+  it('echoes the active nameRegex in the header when a filter was applied', () => {
+    const blocks = obsidianListCommands.format!({
+      commands: [{ id: 'templater-obsidian:new-template', name: 'Templater: New note' }],
+      appliedFilters: { nameRegex: '^Templater' },
+    });
+    const text = (blocks[0] as { text: string }).text;
+    expect(text).toContain('nameRegex=`^Templater`');
+    expect(text).toContain('templater-obsidian:new-template');
+  });
+
+  it('mentions the active nameRegex in the empty-state message', () => {
+    const blocks = obsidianListCommands.format!({
+      commands: [],
+      appliedFilters: { nameRegex: '^nothing-matches$' },
+    });
+    const text = (blocks[0] as { text: string }).text;
+    expect(text).toMatch(/no commands/i);
+    expect(text).toContain('^nothing-matches$');
   });
 });

--- a/tests/tools/obsidian-patch-note.test.ts
+++ b/tests/tools/obsidian-patch-note.test.ts
@@ -41,9 +41,10 @@ describe('obsidian_patch_note', () => {
 
     expect(seenHeaders.operation ?? seenHeaders.Operation).toBe('prepend');
     expect(seenHeaders['target-type'] ?? seenHeaders['Target-Type']).toBe('block');
+    // applyIfContentPreexists: true → omit the Reject header (force-apply path).
     expect(
-      seenHeaders['apply-if-content-preexists'] ?? seenHeaders['Apply-If-Content-Preexists'],
-    ).toBe('true');
+      seenHeaders['reject-if-content-preexists'] ?? seenHeaders['Reject-If-Content-Preexists'],
+    ).toBeUndefined();
     expect(seenHeaders['trim-target-whitespace'] ?? seenHeaders['Trim-Target-Whitespace']).toBe(
       'true',
     );

--- a/tests/tools/obsidian-search-notes.test.ts
+++ b/tests/tools/obsidian-search-notes.test.ts
@@ -1,12 +1,17 @@
 /**
- * @fileoverview Handler tests for obsidian_search_notes across the three modes.
+ * @fileoverview Handler tests for obsidian_search_notes across all four modes,
+ * including cursor pagination round-trips and the Omnisearch-conditional
+ * branch built via `buildSearchNotesTool({ omnisearchReachable: true })`.
  * @module tests/tools/obsidian-search-notes.test
  */
 
 import { JsonRpcErrorCode } from '@cyanheads/mcp-ts-core/errors';
 import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
 import { afterEach, describe, expect, it } from 'vitest';
-import { obsidianSearchNotes } from '@/mcp-server/tools/definitions/obsidian-search-notes.tool.js';
+import {
+  buildSearchNotesTool,
+  obsidianSearchNotes,
+} from '@/mcp-server/tools/definitions/obsidian-search-notes.tool.js';
 import {
   type ObsidianFetch,
   ObsidianService,
@@ -15,6 +20,8 @@ import {
 import { makeTestConfig, setupHarness } from '../helpers.js';
 
 const harness = setupHarness();
+
+const omnisearchTool = buildSearchNotesTool({ omnisearchReachable: true });
 
 describe('obsidian_search_notes / text', () => {
   it('returns text hits and applies pathPrefix client-side', async () => {
@@ -52,6 +59,8 @@ describe('obsidian_search_notes / text', () => {
     if (out.result.mode !== 'text') throw new Error('expected text branch');
     expect(out.result.hits).toHaveLength(1);
     expect(out.result.hits[0]?.filename).toBe('Projects/A.md');
+    expect(out.result.totalCount).toBe(1);
+    expect(out.result.nextCursor).toBeUndefined();
   });
 
   it('throws query_required (ValidationError) when query is missing in text mode', async () => {
@@ -70,8 +79,8 @@ describe('obsidian_search_notes / text', () => {
     await expect(
       obsidianSearchNotes.handler(
         obsidianSearchNotes.input.parse({
-          mode: 'dataview',
-          query: 'TABLE x FROM ""',
+          mode: 'jsonlogic',
+          logic: { var: 'path' },
           pathPrefix: 'Projects/',
         }),
         createMockContext({ errors: obsidianSearchNotes.errors }),
@@ -157,12 +166,23 @@ describe('obsidian_search_notes / text', () => {
     expect(hit?.truncated).toBeUndefined();
     expect(hit?.totalMatches).toBeUndefined();
   });
+});
 
-  it('caps hits at 100 and reports the overflow in `excluded`', async () => {
-    const many = Array.from({ length: 105 }, (_, i) => ({
+describe('obsidian_search_notes / cursor pagination', () => {
+  it('returns nextCursor when more hits remain, and resumes from that cursor', async () => {
+    const many = Array.from({ length: 125 }, (_, i) => ({
       filename: `n${i}.md`,
       matches: [{ context: 'x', match: { start: 0, end: 1 } }],
     }));
+    // Two intercepts — same upstream payload returned for both pages,
+    // since pagination is server-side on the full set.
+    harness
+      .current()
+      .pool.intercept({
+        path: (p) => (p as string).startsWith('/search/simple/'),
+        method: 'POST',
+      })
+      .reply(200, many, { headers: { 'content-type': 'application/json' } });
     harness
       .current()
       .pool.intercept({
@@ -171,31 +191,51 @@ describe('obsidian_search_notes / text', () => {
       })
       .reply(200, many, { headers: { 'content-type': 'application/json' } });
 
-    const out = await obsidianSearchNotes.handler(
+    const first = await obsidianSearchNotes.handler(
       obsidianSearchNotes.input.parse({ mode: 'text', query: 'x' }),
       createMockContext(),
     );
-    if (out.result.mode !== 'text') throw new Error('expected text branch');
-    expect(out.result.hits).toHaveLength(100);
-    expect(out.result.excluded).toEqual({ count: 5, hint: expect.any(String) });
-  });
-});
+    if (first.result.mode !== 'text') throw new Error('expected text branch');
+    expect(first.result.hits).toHaveLength(50); // DEFAULT_PAGE_SIZE
+    expect(first.result.totalCount).toBe(125);
+    expect(first.result.nextCursor).toBeDefined();
 
-describe('obsidian_search_notes / dataview', () => {
-  it('forwards the DQL string and returns structured hits', async () => {
-    harness
-      .current()
-      .pool.intercept({ path: '/search/', method: 'POST' })
-      .reply(200, [{ filename: 'A.md', result: { mtime: 123 } }], {
-        headers: { 'content-type': 'application/json' },
-      });
-
-    const out = await obsidianSearchNotes.handler(
-      obsidianSearchNotes.input.parse({ mode: 'dataview', query: 'TABLE file.mtime FROM ""' }),
+    const second = await obsidianSearchNotes.handler(
+      obsidianSearchNotes.input.parse({
+        mode: 'text',
+        query: 'x',
+        cursor: first.result.nextCursor,
+      }),
       createMockContext(),
     );
-    if (out.result.mode !== 'dataview') throw new Error('expected dataview branch');
-    expect(out.result.hits).toEqual([{ filename: 'A.md', result: { mtime: 123 } }]);
+    if (second.result.mode !== 'text') throw new Error('expected text branch');
+    expect(second.result.hits).toHaveLength(50);
+    expect(second.result.hits[0]?.filename).toBe('n50.md');
+    expect(second.result.totalCount).toBe(125);
+    expect(second.result.nextCursor).toBeDefined();
+  });
+
+  it('throws InvalidParams when cursor is malformed (per MCP spec)', async () => {
+    harness
+      .current()
+      .pool.intercept({
+        path: (p) => (p as string).startsWith('/search/simple/'),
+        method: 'POST',
+      })
+      .reply(
+        200,
+        [{ filename: 'a.md', matches: [{ context: 'c', match: { start: 0, end: 1 } }] }],
+        {
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+
+    await expect(
+      obsidianSearchNotes.handler(
+        obsidianSearchNotes.input.parse({ mode: 'text', query: 'x', cursor: 'not-a-cursor' }),
+        createMockContext(),
+      ),
+    ).rejects.toMatchObject({ code: JsonRpcErrorCode.InvalidParams });
   });
 });
 
@@ -217,6 +257,7 @@ describe('obsidian_search_notes / jsonlogic', () => {
     );
     if (out.result.mode !== 'jsonlogic') throw new Error('expected jsonlogic branch');
     expect(out.result.hits).toEqual([{ filename: 'A.md', result: true }]);
+    expect(out.result.totalCount).toBe(1);
   });
 
   it('throws logic_required (ValidationError) when logic is omitted', async () => {
@@ -232,6 +273,164 @@ describe('obsidian_search_notes / jsonlogic', () => {
   });
 });
 
+describe('obsidian_search_notes / omnisearch (mode-conditional)', () => {
+  it('omits the `omnisearch` mode from the input schema when omnisearchReachable=false', () => {
+    const result = obsidianSearchNotes.input.safeParse({ mode: 'omnisearch', query: 'x' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts the `omnisearch` mode when built with omnisearchReachable=true', () => {
+    const result = omnisearchTool.input.safeParse({ mode: 'omnisearch', query: 'x' });
+    expect(result.success).toBe(true);
+  });
+
+  it('normalizes upstream hits (HTML entities decoded, <br>→newline, path→filename, drops vault)', async () => {
+    harness
+      .current()
+      .pool.intercept({
+        path: (p) => (p as string).startsWith('/search?q='),
+        method: 'GET',
+      })
+      .reply(
+        200,
+        [
+          {
+            basename: 'Note A',
+            excerpt: 'Line 1<br>Line 2 — Bob&#039;s pick &amp; <mark>highlight</mark>',
+            foundWords: ['bob'],
+            matches: [{ match: 'bob', offset: 12 }],
+            path: 'Projects/Note A.md',
+            score: 7.42,
+            vault: 'should-be-dropped',
+          },
+        ],
+        { headers: { 'content-type': 'application/json' } },
+      );
+
+    const out = await omnisearchTool.handler(
+      omnisearchTool.input.parse({ mode: 'omnisearch', query: 'bob' }),
+      createMockContext(),
+    );
+    if (out.result.mode !== 'omnisearch') throw new Error('expected omnisearch branch');
+    expect(out.result.hits).toHaveLength(1);
+    const hit = out.result.hits[0];
+    expect(hit?.filename).toBe('Projects/Note A.md');
+    expect(hit?.basename).toBe('Note A');
+    expect(hit?.score).toBe(7.42);
+    expect(hit?.excerpt).toBe("Line 1\nLine 2 — Bob's pick & <mark>highlight</mark>");
+    expect(hit).not.toHaveProperty('vault');
+    expect(out.result.truncated).toBe(false);
+    expect(out.result.totalCount).toBe(1);
+  });
+
+  it('sets truncated=true when upstream returns exactly 50 hits (the hardwired cap)', async () => {
+    const fifty = Array.from({ length: 50 }, (_, i) => ({
+      basename: `n${i}`,
+      excerpt: '',
+      foundWords: ['x'],
+      matches: [],
+      path: `n${i}.md`,
+      score: 1,
+    }));
+    harness
+      .current()
+      .pool.intercept({
+        path: (p) => (p as string).startsWith('/search?q='),
+        method: 'GET',
+      })
+      .reply(200, fifty, { headers: { 'content-type': 'application/json' } });
+
+    const out = await omnisearchTool.handler(
+      omnisearchTool.input.parse({ mode: 'omnisearch', query: 'x' }),
+      createMockContext(),
+    );
+    if (out.result.mode !== 'omnisearch') throw new Error('expected omnisearch branch');
+    expect(out.result.truncated).toBe(true);
+    expect(out.result.hits).toHaveLength(50);
+  });
+
+  it('throws omnisearch_unreachable when the upstream returns 5xx', async () => {
+    harness
+      .current()
+      .pool.intercept({
+        path: (p) => (p as string).startsWith('/search?q='),
+        method: 'GET',
+      })
+      .reply(503, 'Service Unavailable', { headers: { 'content-type': 'text/plain' } });
+
+    await expect(
+      omnisearchTool.handler(
+        omnisearchTool.input.parse({ mode: 'omnisearch', query: 'x' }),
+        createMockContext({ errors: omnisearchTool.errors }),
+      ),
+    ).rejects.toMatchObject({
+      code: JsonRpcErrorCode.ServiceUnavailable,
+      data: { reason: 'omnisearch_unreachable' },
+    });
+  });
+});
+
+describe('obsidian_search_notes / probeOmnisearch', () => {
+  afterEach(() => {
+    setObsidianService(undefined);
+  });
+
+  it('returns true when upstream returns 200 + application/json + JSON array', async () => {
+    const fetchImpl: ObsidianFetch = async (url) => {
+      if (url.includes(':51361/search')) {
+        return new Response('[]', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected ${url}`);
+    };
+    const svc = new ObsidianService(makeTestConfig(), fetchImpl);
+    expect(await svc.probeOmnisearch()).toBe(true);
+  });
+
+  it('returns false when upstream returns 200 but empty body (unrouted path)', async () => {
+    const fetchImpl: ObsidianFetch = async () =>
+      new Response('', { status: 200, headers: { 'content-type': 'text/plain' } });
+    const svc = new ObsidianService(makeTestConfig(), fetchImpl);
+    expect(await svc.probeOmnisearch()).toBe(false);
+  });
+
+  it('returns false when upstream returns 200 with JSON content-type but non-array body', async () => {
+    const fetchImpl: ObsidianFetch = async () =>
+      new Response('{"error":"x"}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    const svc = new ObsidianService(makeTestConfig(), fetchImpl);
+    expect(await svc.probeOmnisearch()).toBe(false);
+  });
+
+  it('returns false on network error (connection refused)', async () => {
+    const fetchImpl: ObsidianFetch = async () => {
+      throw new TypeError('fetch failed');
+    };
+    const svc = new ObsidianService(makeTestConfig(), fetchImpl);
+    expect(await svc.probeOmnisearch()).toBe(false);
+  });
+
+  it('derives the omnisearch URL from baseUrl host with port 51361, mapping 127.0.0.1 → localhost', () => {
+    const svc = new ObsidianService(
+      makeTestConfig({ baseUrl: 'http://127.0.0.1:27123' }),
+      async () => new Response('[]'),
+    );
+    expect(svc.omnisearchUrl).toBe('http://localhost:51361');
+  });
+
+  it('honors OBSIDIAN_OMNISEARCH_URL override', () => {
+    const svc = new ObsidianService(
+      makeTestConfig({ omnisearchUrl: 'http://omni.example:9999/' }),
+      async () => new Response('[]'),
+    );
+    expect(svc.omnisearchUrl).toBe('http://omni.example:9999');
+  });
+});
+
 describe('obsidian_search_notes / format()', () => {
   it('renders text hits with their context', () => {
     const blocks = obsidianSearchNotes.format!({
@@ -243,20 +442,22 @@ describe('obsidian_search_notes / format()', () => {
             matches: [{ context: 'snippet', match: { start: 0, end: 1 } }],
           },
         ],
-        excluded: undefined,
+        totalCount: 1,
       },
     });
     const text = (blocks[0] as { text: string }).text;
     expect(text).toContain('A.md');
     expect(text).toContain('snippet');
+    expect(text).toContain('1 on this page');
+    expect(text).toContain('1 total');
   });
 
   it('renders structured hits as JSON code blocks', () => {
     const blocks = obsidianSearchNotes.format!({
       result: {
-        mode: 'dataview',
+        mode: 'jsonlogic',
         hits: [{ filename: 'A.md', result: { mtime: 1 } }],
-        excluded: undefined,
+        totalCount: 1,
       },
     });
     const text = (blocks[0] as { text: string }).text;
@@ -276,7 +477,7 @@ describe('obsidian_search_notes / format()', () => {
             totalMatches: 25,
           },
         ],
-        excluded: undefined,
+        totalCount: 1,
       },
     });
     const text = (blocks[0] as { text: string }).text;
@@ -284,17 +485,67 @@ describe('obsidian_search_notes / format()', () => {
     expect(text).toContain('first 1 of 25');
   });
 
-  it('shows the excluded count and hint when results are capped', () => {
+  it('surfaces nextCursor and the more-available indicator when a page has a successor', () => {
     const blocks = obsidianSearchNotes.format!({
       result: {
         mode: 'text',
         hits: [],
-        excluded: { count: 5, hint: 'Narrow your query.' },
+        totalCount: 200,
+        nextCursor: 'opaque-token',
       },
     });
     const text = (blocks[0] as { text: string }).text;
-    expect(text).toContain('Excluded 5');
-    expect(text).toContain('Narrow your query.');
+    expect(text).toContain('more available');
+    expect(text).toContain('opaque-token');
+    expect(text).toContain('200 total');
+  });
+
+  it('renders omnisearch hits with score, foundWords, and quoted excerpt', () => {
+    const blocks = omnisearchTool.format!({
+      result: {
+        mode: 'omnisearch',
+        hits: [
+          {
+            basename: 'Note A',
+            excerpt: 'context around the match',
+            filename: 'Projects/Note A.md',
+            foundWords: ['match'],
+            matches: [{ match: 'match', offset: 14 }],
+            score: 7.4242,
+          },
+        ],
+        totalCount: 1,
+        truncated: false,
+      },
+    });
+    const text = (blocks[0] as { text: string }).text;
+    expect(text).toContain('Projects/Note A.md');
+    expect(text).toContain('score: 7.42');
+    expect(text).toContain('`match`');
+    expect(text).toContain('> context around the match');
+  });
+
+  it('warns about omnisearch truncation when the upstream cap was hit', () => {
+    const blocks = omnisearchTool.format!({
+      result: {
+        mode: 'omnisearch',
+        hits: [
+          {
+            basename: 'n0',
+            excerpt: '',
+            filename: 'n0.md',
+            foundWords: ['x'],
+            matches: [],
+            score: 1,
+          },
+        ],
+        totalCount: 50,
+        truncated: true,
+      },
+    });
+    const text = (blocks[0] as { text: string }).text;
+    expect(text).toContain('50-hit cap');
+    expect(text).toContain('Narrow');
   });
 });
 
@@ -303,7 +554,7 @@ describe('obsidian_search_notes — path-policy post-filter', () => {
     setObsidianService(undefined);
   });
 
-  it('drops text hits outside readPaths silently (no excluded indicator)', async () => {
+  it('drops text hits outside readPaths silently and shrinks totalCount', async () => {
     const fetchImpl: ObsidianFetch = async (url) => {
       const u = new URL(url);
       if (u.pathname.startsWith('/search/simple/')) {
@@ -339,10 +590,10 @@ describe('obsidian_search_notes — path-policy post-filter', () => {
     );
     if (out.result.mode !== 'text') throw new Error('expected text branch');
     expect(out.result.hits.map((h) => h.filename)).toEqual(['public/a.md', 'public/sub/c.md']);
-    expect(out.result.excluded).toBeUndefined();
+    expect(out.result.totalCount).toBe(2);
   });
 
-  it('filters dataview hits against readPaths', async () => {
+  it('filters jsonlogic hits against readPaths', async () => {
     const fetchImpl: ObsidianFetch = async () =>
       new Response(
         JSON.stringify([
@@ -355,10 +606,42 @@ describe('obsidian_search_notes — path-policy post-filter', () => {
     setObsidianService(svc);
 
     const out = await obsidianSearchNotes.handler(
-      obsidianSearchNotes.input.parse({ mode: 'dataview', query: 'TABLE x FROM ""' }),
+      obsidianSearchNotes.input.parse({ mode: 'jsonlogic', logic: { var: 'path' } }),
       createMockContext(),
     );
-    if (out.result.mode !== 'dataview') throw new Error('expected dataview branch');
+    if (out.result.mode !== 'jsonlogic') throw new Error('expected jsonlogic branch');
     expect(out.result.hits.map((h) => h.filename)).toEqual(['public/a.md']);
+    expect(out.result.totalCount).toBe(1);
+  });
+
+  it('filters omnisearch hits against readPaths but computes truncated against the raw upstream', async () => {
+    const fiftyRaw = Array.from({ length: 50 }, (_, i) => ({
+      basename: `n${i}`,
+      excerpt: '',
+      foundWords: ['x'],
+      matches: [],
+      path: i < 5 ? `public/n${i}.md` : `secret/n${i}.md`,
+      score: 1,
+    }));
+    const fetchImpl: ObsidianFetch = async (url) => {
+      if (url.includes(':51361/search')) {
+        return new Response(JSON.stringify(fiftyRaw), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected ${url}`);
+    };
+    const svc = new ObsidianService(makeTestConfig({ readPaths: ['public'] }), fetchImpl);
+    setObsidianService(svc);
+
+    const out = await omnisearchTool.handler(
+      omnisearchTool.input.parse({ mode: 'omnisearch', query: 'x' }),
+      createMockContext(),
+    );
+    if (out.result.mode !== 'omnisearch') throw new Error('expected omnisearch branch');
+    expect(out.result.hits).toHaveLength(5);
+    expect(out.result.totalCount).toBe(5);
+    expect(out.result.truncated).toBe(true);
   });
 });

--- a/tests/tools/obsidian-write-note.test.ts
+++ b/tests/tools/obsidian-write-note.test.ts
@@ -109,7 +109,7 @@ describe('obsidian_write_note (whole file)', () => {
 });
 
 describe('obsidian_write_note (section)', () => {
-  it('PATCHes with replace + heading delimiter + apply-if-content-preexists', async () => {
+  it('PATCHes with replace + heading delimiter (force-apply: no Reject header)', async () => {
     const pool = harness.current().pool;
     pool.intercept({ path: '/vault/Note.md', method: 'HEAD' }).reply(200, '', cl(300));
 
@@ -132,9 +132,11 @@ describe('obsidian_write_note (section)', () => {
     expect(seenHeaders.operation ?? seenHeaders.Operation).toBe('replace');
     expect(seenHeaders['target-type'] ?? seenHeaders['Target-Type']).toBe('heading');
     expect(seenHeaders['target-delimiter'] ?? seenHeaders['Target-Delimiter']).toBe('::');
+    // write-note's section replace hardcodes applyIfContentPreexists: true → no Reject header.
+    // (Replace is exempt at the plugin layer anyway; this just keeps intent explicit.)
     expect(
-      seenHeaders['apply-if-content-preexists'] ?? seenHeaders['Apply-If-Content-Preexists'],
-    ).toBe('true');
+      seenHeaders['reject-if-content-preexists'] ?? seenHeaders['Reject-If-Content-Preexists'],
+    ).toBeUndefined();
     expect(out).toEqual({
       path: 'Note.md',
       sectionTargeted: true,


### PR DESCRIPTION
## 3.2.0 — Omnisearch + cursor pagination on `obsidian_search_notes`

`obsidian_search_notes` gains a fourth mode (`omnisearch`) auto-detected at startup via the [Omnisearch](https://github.com/scambier/obsidian-omnisearch) plugin's HTTP probe — BM25 ranking, typo tolerance, quoted-phrase / `-exclusion` / `path:` / `ext:` filters, and PDF + OCR coverage (via [Text Extractor](https://github.com/scambier/obsidian-text-extractor)). The cap+overflow pattern is replaced with MCP-spec cursor pagination ([2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/utils/pagination)) across all branches. Resolves [#51](https://github.com/cyanheads/obsidian-mcp-server/issues/51).

`obsidian_list_commands` gains a `nameRegex` filter mirroring `obsidian_list_tags` — the safety helper (256-char cap + nested-quantifier rejection) is lifted to `_shared/regex-safety.ts`. Resolves [#53](https://github.com/cyanheads/obsidian-mcp-server/issues/53).

PATCH headers track [Local REST API v4.0.0](https://github.com/coddingtonbear/obsidian-local-rest-api/releases/tag/4.0.0) — `Apply-If-Content-Preexists` → `Reject-If-Content-Preexists` with sense inversion. The public `applyIfContentPreexists` schema field stays unchanged; the service inverts on the way out so the default behavior (idempotent against retries) is preserved.

### Breaking

- `dataview` mode removed from `obsidian_search_notes` — [Local REST API v4.0.0 removed Dataview DQL search](https://github.com/coddingtonbear/obsidian-local-rest-api/releases/tag/4.0.0) upstream. Use `jsonlogic` for path/frontmatter/stat filters, or `omnisearch` for ranked relevance.
- `result.excluded` removed — read `result.totalCount` and check whether `result.nextCursor` is set.
- Minimum Local REST API plugin floor raised to v4.0.0 (required for the patch header rename).

Full release notes: [`changelog/3.2.x/3.2.0.md`](https://github.com/cyanheads/obsidian-mcp-server/blob/main/changelog/3.2.x/3.2.0.md).

