### PR TITLE
Clarify JSONLogic glob argument order

### DIFF
--- a/src/mcp-server/tools/definitions/obsidian-search-notes.tool.ts
+++ b/src/mcp-server/tools/definitions/obsidian-search-notes.tool.ts
@@ -116,8 +116,8 @@ export function buildSearchNotesTool({ omnisearchReachable }: { omnisearchReacha
       .enum(modeEnum)
       .describe(
         omnisearchReachable
-          ? 'Which search algorithm to run. `text` matches a substring case-insensitively across filenames and note bodies, returning surrounding context windows. `jsonlogic` evaluates a JSONLogic tree against each note, with `var` paths into `path`, `content`, `frontmatter.<key>`, `tags`, and `stat.{ctime,mtime,size}`, plus `glob` and `regexp` operators. `omnisearch` runs a BM25-ranked query via the Omnisearch plugin — supports quoted phrases, `-exclusion`, `path:` / `ext:` filters, typo tolerance, and PDF/OCR (with Text Extractor); upstream caps results at 50.'
-          : 'Which search algorithm to run. `text` matches a substring case-insensitively across filenames and note bodies, returning surrounding context windows. `jsonlogic` evaluates a JSONLogic tree against each note, with `var` paths into `path`, `content`, `frontmatter.<key>`, `tags`, and `stat.{ctime,mtime,size}`, plus `glob` and `regexp` operators.',
+          ? 'Which search algorithm to run. `text` matches a substring case-insensitively across filenames and note bodies, returning surrounding context windows. `jsonlogic` evaluates a JSONLogic tree against each note, with `var` paths into `path`, `content`, `frontmatter.<key>`, `tags`, and `stat.{ctime,mtime,size}`, plus `glob` and `regexp` operators whose argument order is `[pattern, value]`. `omnisearch` runs a BM25-ranked query via the Omnisearch plugin — supports quoted phrases, `-exclusion`, `path:` / `ext:` filters, typo tolerance, and PDF/OCR (with Text Extractor); upstream caps results at 50.'
+          : 'Which search algorithm to run. `text` matches a substring case-insensitively across filenames and note bodies, returning surrounding context windows. `jsonlogic` evaluates a JSONLogic tree against each note, with `var` paths into `path`, `content`, `frontmatter.<key>`, `tags`, and `stat.{ctime,mtime,size}`, plus `glob` and `regexp` operators whose argument order is `[pattern, value]`.',
       ),
     query: z
       .string()
@@ -241,7 +241,7 @@ export function buildSearchNotesTool({ omnisearchReachable }: { omnisearchReacha
       code: JsonRpcErrorCode.ValidationError,
       when: '`logic` is missing for `jsonlogic` mode.',
       recovery:
-        'Pass a JSONLogic tree as `logic`, e.g. `{"glob": [{"var": "path"}, "Projects/*.md"]}`.',
+        'Pass a JSONLogic tree as `logic`, e.g. `{"glob": ["Projects/*.md", {"var": "path"}]}` (custom operator argument order is `[pattern, value]`).',
     },
     {
       reason: 'omnisearch_unreachable',

--- a/tests/tools/obsidian-search-notes.test.ts
+++ b/tests/tools/obsidian-search-notes.test.ts
@@ -271,6 +271,13 @@ describe('obsidian_search_notes / jsonlogic', () => {
       data: { reason: 'logic_required' },
     });
   });
+
+  it('documents custom JSONLogic operator argument order as pattern first', () => {
+    const logicRequired = obsidianSearchNotes.errors.find((e) => e.reason === 'logic_required');
+    expect(logicRequired?.recovery).toContain('{"glob": ["Projects/*.md", {"var": "path"}]}');
+    expect(logicRequired?.recovery).toContain('[pattern, value]');
+    expect(logicRequired?.recovery).not.toContain('{"glob": [{"var": "path"}, "Projects/*.md"]}');
+  });
 });
 
 describe('obsidian_search_notes / omnisearch (mode-conditional)', () => {


### PR DESCRIPTION
## Summary

Clarifies the argument order for the custom JSONLogic `glob` and `regexp` operators used by `obsidian_search_notes`.

## Why

The current recovery example shows the value before the pattern:

```json
{"glob": [{"var": "path"}, "Projects/*.md"]}
```

The operator expects the pattern first. This can lead callers to construct valid-looking JSONLogic queries that return no matches.

## Changes

- Document that the custom operator argument order is `[pattern, value]`.
- Update the `logic_required` recovery example to use the pattern-first form.
- Add a regression test so the recovery text does not drift back to the value-first example.

## Tests

- `bunx vitest run tests/tools/obsidian-search-notes.test.ts` — 31 passed
- `bun run build`
- `bun run test` — 397 passed
