### PR TITLE
Set Obsidian client keep-alive timeout

### DIFF
--- a/src/services/obsidian/obsidian-service.ts
+++ b/src/services/obsidian/obsidian-service.ts
@@ -31,6 +31,8 @@ import type {
   VaultStatus,
 } from './types.js';
 
+export const OBSIDIAN_AGENT_KEEP_ALIVE_TIMEOUT_MS = 4_000;
+
 type UndiciResponse = Awaited<ReturnType<typeof undiciFetch>>;
 
 /**
@@ -43,6 +45,16 @@ export type ObsidianFetch = (
   url: string,
   init: RequestInit & { dispatcher?: Dispatcher; signal?: AbortSignal },
 ) => Promise<UndiciResponse>;
+
+export function buildObsidianAgentOptions(config: ServerConfig): ConstructorParameters<typeof Agent>[0] {
+  return {
+    connect: { rejectUnauthorized: config.verifySsl },
+    headersTimeout: config.requestTimeoutMs,
+    bodyTimeout: config.requestTimeoutMs,
+    keepAliveTimeout: OBSIDIAN_AGENT_KEEP_ALIVE_TIMEOUT_MS,
+    keepAliveMaxTimeout: OBSIDIAN_AGENT_KEEP_ALIVE_TIMEOUT_MS,
+  };
+}
 
 interface UpstreamErrorBody {
   errorCode?: number;
@@ -133,11 +145,7 @@ export class ObsidianService {
     if (!config.verifySsl && typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined') {
       process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
     }
-    this.#dispatcher = new Agent({
-      connect: { rejectUnauthorized: config.verifySsl },
-      headersTimeout: config.requestTimeoutMs,
-      bodyTimeout: config.requestTimeoutMs,
-    });
+    this.#dispatcher = new Agent(buildObsidianAgentOptions(config));
     this.#fetch = fetchImpl ?? (undiciFetch as ObsidianFetch);
   }
 

--- a/tests/services/obsidian-service.test.ts
+++ b/tests/services/obsidian-service.test.ts
@@ -9,8 +9,19 @@ import type { Context } from '@cyanheads/mcp-ts-core';
 import { JsonRpcErrorCode } from '@cyanheads/mcp-ts-core/errors';
 import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { encodeVaultPath, type ObsidianService } from '@/services/obsidian/obsidian-service.js';
-import { type PathMatcher, type ReplyFn, setupHarness, type TestHarness } from '../helpers.js';
+import {
+  buildObsidianAgentOptions,
+  encodeVaultPath,
+  OBSIDIAN_AGENT_KEEP_ALIVE_TIMEOUT_MS,
+  type ObsidianService,
+} from '@/services/obsidian/obsidian-service.js';
+import {
+  makeTestConfig,
+  type PathMatcher,
+  type ReplyFn,
+  setupHarness,
+  type TestHarness,
+} from '../helpers.js';
 
 const harness = setupHarness();
 let pool: TestHarness['pool'];
@@ -21,6 +32,17 @@ beforeEach(() => {
   pool = harness.current().pool;
   service = harness.current().service;
   ctx = createMockContext();
+});
+
+describe('ObsidianService agent options', () => {
+  it('sets explicit keep-alive timeouts below the upstream server timeout', () => {
+    const options = buildObsidianAgentOptions(makeTestConfig({ requestTimeoutMs: 30_000 }));
+
+    expect(options?.keepAliveTimeout).toBe(OBSIDIAN_AGENT_KEEP_ALIVE_TIMEOUT_MS);
+    expect(options?.keepAliveMaxTimeout).toBe(OBSIDIAN_AGENT_KEEP_ALIVE_TIMEOUT_MS);
+    expect(options?.headersTimeout).toBe(30_000);
+    expect(options?.bodyTimeout).toBe(30_000);
+  });
 });
 
 describe('ObsidianService.getStatus', () => {


### PR DESCRIPTION
## Summary
- set explicit undici Agent keep-alive timeouts for the Obsidian REST client
- keep the client idle timeout below the Local REST API server keep-alive timeout
- add regression coverage for the Agent option builder

## Why
Short, explicit client-side keep-alive avoids stale-socket reuse races against upstream servers with short keep-alive windows.

## Tests
- `bun test tests/services/obsidian-service.test.ts`
- `bun run test`
- `bun run build`
- `bun run lint:mcp`
