### PR TITLE
Filter Obsidian pseudo-tags

### DIFF
--- a/src/services/obsidian/obsidian-service.ts
+++ b/src/services/obsidian/obsidian-service.ts
@@ -106,6 +106,19 @@ const JSONLOGIC_CT = 'application/vnd.olrapi.jsonlogic+json';
  */
 const RETRY_SAFE_METHODS: ReadonlySet<string> = new Set(['GET', 'PUT', 'DELETE']);
 
+const CSS_HEX_COLOR_TAG_RE = /^(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+/**
+ * Obsidian's tag tokenizer surfaces CSS color literals (`#rrggbb` / `#rrggbbaa`)
+ * from prose and code as tags. Filter only the unambiguous 6- and 8-hex form:
+ * 3-hex and pure-numeric names are deliberately NOT filtered because they collide
+ * with legitimate short tags (`ace`, `bad`, `fed`) and year tags (`2024`, `1984`).
+ */
+export function isObsidianPseudoTag(name: string): boolean {
+  const bare = name.startsWith('#') ? name.slice(1) : name;
+  return CSS_HEX_COLOR_TAG_RE.test(bare);
+}
+
 export class ObsidianService {
   readonly #config: ServerConfig;
   readonly #dispatcher: Dispatcher;
@@ -377,7 +390,7 @@ export class ObsidianService {
   async listTags(ctx: Context): Promise<ObsidianTag[]> {
     const res = await this.#request(ctx, '/tags/', { method: 'GET' });
     const body = (await res.json()) as RawTagsListing;
-    return body.tags ?? [];
+    return (body.tags ?? []).filter((tag) => !isObsidianPseudoTag(tag.name));
   }
 
   async listCommands(ctx: Context): Promise<ObsidianCommand[]> {

--- a/tests/services/obsidian-pseudo-tag.test.ts
+++ b/tests/services/obsidian-pseudo-tag.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @fileoverview Unit tests for the pseudo-tag filter used by `listTags` to drop
+ * CSS color literals that Obsidian's tag tokenizer surfaces from prose/code.
+ * @module tests/services/obsidian-pseudo-tag.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isObsidianPseudoTag } from '@/services/obsidian/obsidian-service.js';
+
+describe('isObsidianPseudoTag', () => {
+  it('filters 6- and 8-digit hex color literals', () => {
+    for (const t of ['ffffff', 'FFFFFF', '00ff00', 'deadbe', 'ffffffff', '00ff00ff']) {
+      expect(isObsidianPseudoTag(t)).toBe(true);
+    }
+  });
+
+  it('strips a leading "#" before testing', () => {
+    expect(isObsidianPseudoTag('#ffffff')).toBe(true);
+  });
+
+  it('keeps 3-hex names and pure-numeric / year tags', () => {
+    for (const t of ['fff', 'ace', 'bad', 'fed', '2024', '1984', '42']) {
+      expect(isObsidianPseudoTag(t)).toBe(false);
+    }
+  });
+
+  it('keeps ordinary and hierarchical tags', () => {
+    for (const t of ['project', 'work/tasks', 'cafe', 'decade-review']) {
+      expect(isObsidianPseudoTag(t)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- filter CSS color literals (`#rrggbb` / `#rrggbbaa`) out of the Local REST API `/tags/` response
- apply the filter in the service layer so `obsidian_list_tags` and `obsidian://tags` stay consistent
- scope it narrowly to the **unambiguous 6- and 8-hex form only**

## Why
Obsidian's tag tokenizer can report CSS color literals from prose or code as tags. Filtering the 6/8-hex form makes tag listings cleaner. Pure-numeric names and 3-hex names are deliberately **not** filtered — they collide with legitimate short tags (`ace`, `bad`, `fed`) and year tags (`2024`, `1984`), so dropping them would be surprising data loss.

## Tests
- `bun test tests/services/obsidian-pseudo-tag.test.ts`
- `bun run test` (full suite green)
- `bun run test:types`

## Note
Branch rebased onto current `main`. The filter is narrowed to 6/8-hex only (down from an earlier numeric + 3/6/8-hex version) after review feedback that the broader form dropped legitimate year/short tags.
