### PR TITLE
Handle empty frontmatter in local helpers

### DIFF
--- a/src/services/obsidian/frontmatter-ops.ts
+++ b/src/services/obsidian/frontmatter-ops.ts
@@ -7,7 +7,7 @@
 
 import { type Document, isMap, parseDocument } from 'yaml';
 
-const FM_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+const FM_RE = /^---(?:\r\n|\n)([\s\S]*?)^---(?:\r\n|\n|$)/m;
 
 interface Splice {
   body: string;

--- a/src/services/obsidian/frontmatter-ops.ts
+++ b/src/services/obsidian/frontmatter-ops.ts
@@ -7,7 +7,12 @@
 
 import { type Document, isMap, parseDocument } from 'yaml';
 
-const FM_RE = /^---(?:\r\n|\n)([\s\S]*?)^---(?:\r\n|\n|$)/m;
+// Anchored to string start only (NO /m flag): the opening `---` must be the very
+// first line. With /m the opening `^---` could match a `---` line mid-body, and
+// splice() slices via m[0].length assuming the match is at index 0 → silent content
+// corruption on notes that have no frontmatter but contain `---` lines in the body.
+// The optional content group lets an empty block (`---\n---\n`) still match.
+const FM_RE = /^---\r?\n(?:([\s\S]*?)\r?\n)?---(?:\r?\n|$)/;
 
 interface Splice {
   body: string;

--- a/tests/services/frontmatter-ops.test.ts
+++ b/tests/services/frontmatter-ops.test.ts
@@ -12,7 +12,7 @@ import {
   reconcileTags,
 } from '@/services/obsidian/frontmatter-ops.js';
 
-const FM_BLOCK_RE = /^---(?:\r\n|\n)([\s\S]*?)^---(?:\r\n|\n|$)/m;
+const FM_BLOCK_RE = /^---\r?\n(?:([\s\S]*?)\r?\n)?---(?:\r?\n|$)/;
 
 function readFrontmatter(content: string): Record<string, unknown> {
   const m = FM_BLOCK_RE.exec(content);
@@ -38,6 +38,13 @@ describe('deleteFrontmatterKey', () => {
   it('returns content unchanged when there is no frontmatter', () => {
     const input = '# Just a heading\nbody';
     expect(deleteFrontmatterKey(input, 'title')).toBe(input);
+  });
+
+  it('leaves a body with thematic-break `---` lines untouched (no false frontmatter match)', () => {
+    // No frontmatter, but two `---` lines in the body. A multiline-anchored regex
+    // would mis-match these as a frontmatter block and corrupt the content.
+    const input = ['intro', '---', 'x', '---', 'body'].join('\n');
+    expect(deleteFrontmatterKey(input, 'missing')).toBe(input);
   });
 
   it('strips the entire frontmatter block when the last key is removed', () => {

--- a/tests/services/frontmatter-ops.test.ts
+++ b/tests/services/frontmatter-ops.test.ts
@@ -12,7 +12,7 @@ import {
   reconcileTags,
 } from '@/services/obsidian/frontmatter-ops.js';
 
-const FM_BLOCK_RE = /^---\n([\s\S]*?)\n---\n?/;
+const FM_BLOCK_RE = /^---(?:\r\n|\n)([\s\S]*?)^---(?:\r\n|\n|$)/m;
 
 function readFrontmatter(content: string): Record<string, unknown> {
   const m = FM_BLOCK_RE.exec(content);
@@ -46,6 +46,11 @@ describe('deleteFrontmatterKey', () => {
     expect(out.startsWith('---')).toBe(false);
     expect(out).toContain('Body.');
   });
+
+  it('recognizes an empty frontmatter block when deleting an absent key', () => {
+    const input = ['---', '---', '# H', 'Body.'].join('\n');
+    expect(deleteFrontmatterKey(input, 'missing')).toBe(input);
+  });
 });
 
 describe('reconcileTags / add', () => {
@@ -55,6 +60,27 @@ describe('reconcileTags / add', () => {
     expect(r.applied).toEqual(['b']);
     expect(r.skipped).toEqual([]);
     expect(readFrontmatter(r.content).tags).toEqual(['a', 'b']);
+  });
+
+  it('adds a tag to an empty frontmatter block without duplicating it', () => {
+    const input = ['---', '---', '# H', 'Body.'].join('\n');
+    const r = reconcileTags(input, ['fresh'], 'add', 'frontmatter');
+
+    expect(r.applied).toEqual(['fresh']);
+    expect(r.skipped).toEqual([]);
+    expect(readFrontmatter(r.content).tags).toEqual(['fresh']);
+    expect(r.content).not.toContain('\n---\n---\n');
+    expect(r.content).toContain('# H\nBody.');
+  });
+
+  it('adds a tag to an empty CRLF frontmatter block without duplicating it', () => {
+    const input = '---\r\n---\r\n# H\r\nBody.\r\n';
+    const r = reconcileTags(input, ['fresh'], 'add', 'frontmatter');
+
+    expect(r.applied).toEqual(['fresh']);
+    expect(readFrontmatter(r.content).tags).toEqual(['fresh']);
+    expect(r.content).not.toContain('\r\n---\r\n---\r\n');
+    expect(r.content).toContain('# H\r\nBody.\r\n');
   });
 
   it('marks an already-present frontmatter tag as skipped', () => {


### PR DESCRIPTION
## Summary
- recognize empty YAML frontmatter blocks (`---\n---\n`) in the local frontmatter helpers
- anchor the matcher to the **start of the document** (no `/m` flag) so `---` lines in the body (thematic breaks) are never mistaken for a frontmatter block
- avoid duplicating `---\n---` when adding frontmatter tags to a note with an empty block
- LF/CRLF empty-block coverage plus a regression test for body-only `---` lines

## Why
The composed tag/frontmatter helpers read and rewrite raw note content for operations that have no single Local REST API equivalent. The matcher missed valid empty frontmatter blocks.

A multiline-anchored fix would over-match: with `/m`, the opening `^---` can match a `---` line mid-body, and because `splice()` slices via `m[0].length` (assuming the match is at index 0), a note with no frontmatter but `---` lines in the body would be silently corrupted. The matcher is therefore anchored to string start with an optional content group — this handles the empty block without the false positive.

## Tests
- `bun test tests/services/frontmatter-ops.test.ts`
- `bun run test` (full suite green)
- `bun run test:types`
