### PR TITLE
fix(manage_frontmatter): type value input as a union so clients serialize structured values correctly

### DIFF
--- a/src/mcp-server/tools/definitions/obsidian-manage-frontmatter.tool.ts
+++ b/src/mcp-server/tools/definitions/obsidian-manage-frontmatter.tool.ts
@@ -24,7 +24,14 @@ export const obsidianManageFrontmatter = tool('obsidian_manage_frontmatter', {
     target: TargetSchema.describe('Where the note lives.'),
     key: z.string().min(1).describe('Frontmatter field name.'),
     value: z
-      .unknown()
+      .union([
+        z.string(),
+        z.number(),
+        z.boolean(),
+        z.array(z.unknown()),
+        z.record(z.string(), z.unknown()),
+        z.null(),
+      ])
       .optional()
       .describe(
         'Required when `operation` is `"set"`. JSON-typed value to write — strings, numbers, booleans, arrays, and objects all accepted.',

--- a/tests/tools/obsidian-manage-frontmatter.test.ts
+++ b/tests/tools/obsidian-manage-frontmatter.test.ts
@@ -104,6 +104,56 @@ describe('obsidian_manage_frontmatter / set', () => {
     expect(out.result.currentSizeInBytes).toBe(Buffer.byteLength('body', 'utf8'));
   });
 
+  /**
+   * Regression coverage for the typed `value` union. Each JSON type must reach
+   * the PATCH body as its own `JSON.stringify` form (a single encoding layer)
+   * and round-trip back through the post-PATCH GET unchanged — no extra
+   * stringification. With a typeless `z.unknown()` input the rendered JSON
+   * Schema carries no `type`, which leads MCP clients to pre-stringify
+   * non-string values and double-encode them (e.g. `[1,2]` stored as the
+   * string `"[1,2]"`); the explicit union gives clients the type information
+   * to serialize correctly.
+   */
+  it.each([
+    { label: 'string', value: 'done', body: '"done"' },
+    { label: 'boolean', value: true, body: 'true' },
+    { label: 'array', value: ['alpha', 'beta'], body: '["alpha","beta"]' },
+    { label: 'object', value: { a: 1 }, body: '{"a":1}' },
+  ])('serializes a $label value as a single JSON layer in the PATCH body', async ({
+    value,
+    body,
+  }) => {
+    const pool = harness.current().pool;
+    pool
+      .intercept({ path: '/vault/N.md', method: 'HEAD' })
+      .reply(200, '', { headers: { 'content-length': '50' } });
+
+    let seenBody = '';
+    pool.intercept({ path: '/vault/N.md', method: 'PATCH' }).reply((opts) => {
+      seenBody = String(opts.body ?? '');
+      return { statusCode: 200, data: '' };
+    });
+    pool
+      .intercept({ path: '/vault/N.md', method: 'GET' })
+      .reply(200, noteJson('body', { field: value }), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+    const out = await obsidianManageFrontmatter.handler(
+      obsidianManageFrontmatter.input.parse({
+        operation: 'set',
+        target: { type: 'path', path: 'N.md' },
+        key: 'field',
+        value,
+      }),
+      createMockContext(),
+    );
+
+    expect(seenBody).toBe(body);
+    if (out.result.operation !== 'set') throw new Error('expected set branch');
+    expect(out.result.frontmatter).toEqual({ field: value });
+  });
+
   it('throws value_required (ValidationError) when value is missing for set', async () => {
     await expect(
       obsidianManageFrontmatter.handler(


### PR DESCRIPTION
## Summary

The `set` operation's `value` input is typed `z.unknown()`, so the rendered JSON Schema for the field carries no `type`. MCP clients that infer wire serialization from the schema (Claude Code does) then transmit non-string values as their JSON-string form; the handler `JSON.stringify`s again before PATCHing, producing a double-encoded result:

- number `42` → stored as `"42"` (type lost)
- array `["a","b"]` → stored as the string `'["a","b"]'`
- objects likewise; **strings are unaffected** (stringify+parse is identity for a bare string)

This is the unresolved tail of #20 / #21 / #54. Those closed cleanly for the unit suite — but the unit tests call `input.parse()` with native JS values, which bypasses the client transport where the mis-serialization actually happens, so they structurally can't catch it.

## Verification

Reproduced and fixed end-to-end against a live Obsidian Local REST API using the Claude Code MCP client (server v3.1.5, Windows 11). Pre-fix: `42`→`"42"`, `["alpha","beta"]`→`'["alpha","beta"]'`. Post-fix: number→`42`, array→a real YAML list, boolean→`true`, string→clean.

## Fix

Replace `z.unknown()` with an explicit `z.union` of the documented JSON types, so the rendered schema instructs clients to send real typed values rather than pre-stringified strings. No caller-contract change, and the existing native-value tests stay green.

(#54 proposed `z.string()` + server-side `JSON.parse`; the union achieves the same correctness without changing the caller contract.)

Adds round-trip coverage in the `set` handler for string / boolean / array / object values.
