### PR TITLE
perf(search): clip text-search matches after pagination

### DIFF
--- a/src/mcp-server/tools/definitions/obsidian-search-notes.tool.ts
+++ b/src/mcp-server/tools/definitions/obsidian-search-notes.tool.ts
@@ -299,14 +299,16 @@ export function buildSearchNotesTool({ omnisearchReachable }: { omnisearchReacha
         const prefix = input.pathPrefix;
         const prefixed = prefix ? raw.filter((h) => h.filename.startsWith(prefix)) : raw;
         const allowed = policy.filterReadable(prefixed);
-        const clipped = allowed.map((h) => clipMatches(h, input.maxMatchesPerHit));
-        const page = paginate(clipped, input.cursor, ctx);
-        if (page.hits.length === 0) {
+        const page = paginate(allowed, input.cursor, ctx);
+        // Clip only this page's hits — clipping before pagination would map over
+        // every match (thousands on a large vault) just to discard all but the page.
+        const hits = page.hits.map((h) => clipMatches(h, input.maxMatchesPerHit));
+        if (hits.length === 0) {
           ctx.enrich.notice(
             `No matches for "${input.query}"${prefix ? ` under prefix "${prefix}"` : ''}. Try broader terms, a different mode, or check that the path/filter is correct.`,
           );
         }
-        return { result: { mode: 'text' as const, ...page } };
+        return { result: { mode: 'text' as const, ...page, hits } };
       }
 
       if (input.mode === 'jsonlogic') {


### PR DESCRIPTION
Text mode mapped `clipMatches` over every hit before `paginate` discarded all but the ~50-hit page. On a large vault a substring can match thousands of notes, so the clip ran across the whole set only to keep one page's worth.

Reorder so pagination runs on `allowed`, then clip only `page.hits`.

**Behavior-preserving:** `map` preserves length and order, so `totalCount` (`== allowed.length`) and the offset-based cursor are unchanged; `truncated`/`totalMatches` still land on the page hits `format()` renders. The `...page` spread is applied before the `hits` override.

**Effect:** trims a transient N-element array to ≤50 per text search. Low-severity — references only, no note-body copies.

**Verification:** `tsc --noEmit` clean · `lint:mcp` all definitions valid · full suite 407/407 (search-notes 32/32).